### PR TITLE
Origin/dev/mip 249 stop algo execution if node stops responding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@
    cdes_metadata_path = "./tests/demo_data"
 
    node_registry_update_interval = 30
-   celery_tasks_timeout = 10
 
    [[nodes]]
    id = "globalnode"

--- a/mipengine/algorithms/result.py
+++ b/mipengine/algorithms/result.py
@@ -11,3 +11,8 @@ class TabularDataResult(BaseModel):
     title: str
     columns: List[TabularDataColumn]
     data: List[List[Union[float, str]]]
+
+
+class ErrorResult(BaseModel):
+    error_title: str
+    description: str

--- a/mipengine/algorithms/result.py
+++ b/mipengine/algorithms/result.py
@@ -11,8 +11,3 @@ class TabularDataResult(BaseModel):
     title: str
     columns: List[TabularDataColumn]
     data: List[List[Union[float, str]]]
-
-
-class ErrorResult(BaseModel):
-    error_title: str
-    description: str

--- a/mipengine/controller/algorithm_executor.py
+++ b/mipengine/controller/algorithm_executor.py
@@ -250,9 +250,11 @@ class _Node:
         return self._node_tasks_handler.get_table_schema(
             table_name=table_name.full_table_name
         )
+
     @time_limit_exceeded_handler
     def get_table_data(self, table_name: _TableName) -> TableData:
         return self._node_tasks_handler.get_table_data(table_name.full_table_name)
+
     @time_limit_exceeded_handler
     def create_table(self, command_id: str, schema: TableSchema) -> _TableName:
         schema_json = schema.json()

--- a/mipengine/controller/algorithm_executor.py
+++ b/mipengine/controller/algorithm_executor.py
@@ -460,7 +460,7 @@ class _AlgorithmExecutionInterface:
                 # TODO _node_tasks_handler and _task_timeout are internals of node and
                 # should not be accessed. This should be a temporary solution.
 
-                # TODO The folloing time limit related exceptions are raised when get()
+                # TODO The following time limit related exceptions are raised when get()
                 # is called. This is the reason they are catched in 2 different classes
                 # here(_AlgorithmExecutionInterface) as well as in the _Node class
                 # (thru the @time_limit_exceeded_handler decoration). This is not ideal,
@@ -540,7 +540,7 @@ class _AlgorithmExecutionInterface:
             # TODO _node_tasks_handler and _task_timeout are internals of node and
             # should not be accessed. This should be a temporary solution.
 
-            # TODO The folloing time limit related exceptions are raised when get()
+            # TODO The following time limit related exceptions are raised when get()
             # is called. This is the reason they are catched in 2 different classes
             # here(_AlgorithmExecutionInterface) as well as in the _Node class
             # (thru the @time_limit_exceeded_handler decoration). This is not ideal,

--- a/mipengine/controller/api/error_handlers.py
+++ b/mipengine/controller/api/error_handlers.py
@@ -6,6 +6,7 @@ from quart import Blueprint
 from mipengine.controller.api.exceptions import BadRequest
 from mipengine.controller.api.exceptions import BadUserInput
 from mipengine.node_tasks_DTOs import InsufficientDataError
+from mipengine.controller.algorithm_executor import AlgorithmExecutionException
 
 error_handlers = Blueprint("error_handlers", __name__)
 
@@ -16,7 +17,13 @@ class HTTPStatusCode(enum.IntEnum):
     BAD_REQUEST = 400
     BAD_USER_INPUT = 460
     INSUFFICIENT_DATA_ERROR = 461
+    ALGORITHM_EXECUTION_ERROR = 462
     UNEXPECTED_ERROR = 500
+
+
+@error_handlers.app_errorhandler(AlgorithmExecutionException)
+def handle_algorithm_execution_exception(error: AlgorithmExecutionException):
+    return error.message, HTTPStatusCode.ALGORITHM_EXECUTION_ERROR
 
 
 @error_handlers.app_errorhandler(BadRequest)

--- a/mipengine/controller/api/error_handlers.py
+++ b/mipengine/controller/api/error_handlers.py
@@ -17,13 +17,7 @@ class HTTPStatusCode(enum.IntEnum):
     BAD_REQUEST = 400
     BAD_USER_INPUT = 460
     INSUFFICIENT_DATA_ERROR = 461
-    ALGORITHM_EXECUTION_ERROR = 462
     UNEXPECTED_ERROR = 500
-
-
-@error_handlers.app_errorhandler(AlgorithmExecutionException)
-def handle_algorithm_execution_exception(error: AlgorithmExecutionException):
-    return error.message, HTTPStatusCode.ALGORITHM_EXECUTION_ERROR
 
 
 @error_handlers.app_errorhandler(BadRequest)

--- a/mipengine/controller/celery_app.py
+++ b/mipengine/controller/celery_app.py
@@ -5,7 +5,7 @@ from celery import Celery
 
 from mipengine.controller import config as controller_config
 
-CELERY_TASKS_TIMEOUT = controller_config.celery_tasks_timeout
+CELERY_TASKS_TIMEOUT = controller_config.rabbitmq.celery_tasks_timeout
 
 
 def get_node_celery_app(socket_addr):

--- a/mipengine/controller/config.toml
+++ b/mipengine/controller/config.toml
@@ -4,7 +4,6 @@ cdes_metadata_path = "$CDES_METADATA_PATH"
 deployment_type="$DEPLOYMENT_TYPE"
 
 node_registry_update_interval="$NODE_REGISTRY_UPDATE_INTERVAL"
-celery_tasks_timeout="$CELERY_TASKS_TIMEOUT"
 
 [localnodes]
 config_file="$LOCALNODES_CONFIG_FILE"
@@ -15,8 +14,7 @@ port="$LOCALNODES_PORT"
 user = "user"
 password = "password"
 vhost = "user_vhost"
-
-celery_tasks_timeout = 10
+celery_tasks_timeout=5
 celery_tasks_max_retries=3
 celery_tasks_interval_start=0
 celery_tasks_interval_step=0.2

--- a/mipengine/controller/controller.py
+++ b/mipengine/controller/controller.py
@@ -143,8 +143,7 @@ class Controller:
             interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
             interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
             interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
-            tasks_timeout=controller_config.celery_tasks_timeout
-
+            tasks_timeout=controller_config.celery_tasks_timeout,
         )
         # Instantiate the INodeTasksHandler for the Global Node
         global_node_tasks_handler = NodeTasksHandlerCelery(
@@ -166,7 +165,7 @@ class Controller:
                 interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
                 interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
                 interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
-                tasks_timeout=controller_config.celery_tasks_timeout
+                tasks_timeout=controller_config.celery_tasks_timeout,
             )
 
             # Instantiate the INodeTasksHandlers for the Local Nodes

--- a/mipengine/controller/controller.py
+++ b/mipengine/controller/controller.py
@@ -143,6 +143,8 @@ class Controller:
             interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
             interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
             interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
+            tasks_timeout=controller_config.celery_tasks_timeout
+
         )
         # Instantiate the INodeTasksHandler for the Global Node
         global_node_tasks_handler = NodeTasksHandlerCelery(
@@ -164,6 +166,7 @@ class Controller:
                 interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
                 interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
                 interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
+                tasks_timeout=controller_config.celery_tasks_timeout
             )
 
             # Instantiate the INodeTasksHandlers for the Local Nodes

--- a/mipengine/controller/controller.py
+++ b/mipengine/controller/controller.py
@@ -143,7 +143,7 @@ class Controller:
             interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
             interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
             interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
-            tasks_timeout=controller_config.celery_tasks_timeout,
+            tasks_timeout=controller_config.rabbitmq.celery_tasks_timeout,
         )
         # Instantiate the INodeTasksHandler for the Global Node
         global_node_tasks_handler = NodeTasksHandlerCelery(
@@ -165,7 +165,7 @@ class Controller:
                 interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
                 interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
                 interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
-                tasks_timeout=controller_config.celery_tasks_timeout,
+                tasks_timeout=controller_config.rabbitmq.celery_tasks_timeout,
             )
 
             # Instantiate the INodeTasksHandlers for the Local Nodes

--- a/mipengine/controller/node_tasks_handler_celery.py
+++ b/mipengine/controller/node_tasks_handler_celery.py
@@ -1,8 +1,14 @@
 from mipengine.controller.node_tasks_handler_interface import INodeTasksHandler
+from mipengine.controller.node_tasks_handler_interface import IQueueUDFAsyncResult
 from pydantic import BaseModel, conint
 from ipaddress import IPv4Address
 from celery import Celery
-from typing import List, Tuple, Final
+
+from typing import List, Tuple, Final, Callable
+
+from celery.exceptions import TimeoutError
+from billiard.exceptions import SoftTimeLimitExceeded
+from billiard.exceptions import TimeLimitExceeded
 
 from mipengine.controller import config as controller_config
 from mipengine.node_tasks_DTOs import TableData
@@ -27,6 +33,11 @@ TASK_SIGNATURES: Final = {
 }
 
 
+class QueueUDFAsyncResult(IQueueUDFAsyncResult):
+    def get(self, timeout=None):
+        return self.async_result.get(timeout)
+
+
 class CeleryParamsDTO(BaseModel):
     task_queue_domain: IPv4Address
     task_queue_port: conint(ge=1024, le=65535)
@@ -43,6 +54,29 @@ class CeleryParamsDTO(BaseModel):
     interval_start: conint(ge=0)
     interval_step: conint(ge=0)
     interval_max: conint(ge=0)
+
+
+def time_limit_exceeded_handler(method: Callable):
+    def inner(ref, *args, **kargs):
+        try:
+            return method(ref, *args, **kargs)
+        except SoftTimeLimitExceeded as stle:
+            # TODO should use kwargs here..
+            raise SoftTimeLimitExceeded(
+                {"node_id": ref.node_id, "task": method.__name__, "args": args}
+            )
+        except TimeLimitExceeded as tle:
+            # TODO should use kwargs here..
+            raise TimeLimitExceeded(
+                {"node_id": ref.node_id, "task": method.__name__, "args": args}
+            )
+        except TimeoutError as te:
+            # TODO should use kwargs here..
+            raise TimeoutError(
+                {"node_id": ref.node_id, "task": method.__name__, "args": args}
+            )
+
+    return inner
 
 
 class NodeTasksHandlerCelery(INodeTasksHandler):
@@ -87,21 +121,25 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
         return self._db_address
 
     # TABLES functionality
+    @time_limit_exceeded_handler
     def get_tables(self, context_id: str) -> List[str]:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_tables"])
         result = task_signature.delay(context_id=context_id).get(self._task_timeout)
         return [table_name for table_name in result]
 
+    @time_limit_exceeded_handler
     def get_table_schema(self, table_name: str):
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_table_schema"])
         result = task_signature.delay(table_name=table_name).get(self._task_timeout)
         return TableSchema.parse_raw(result)
 
+    @time_limit_exceeded_handler
     def get_table_data(self, table_name: str) -> TableData:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_table_data"])
         result = task_signature.delay(table_name=table_name).get(self._task_timeout)
         return TableData.parse_raw(result)
 
+    @time_limit_exceeded_handler
     def create_table(
         self, context_id: str, command_id: str, schema: TableSchema
     ) -> str:
@@ -113,12 +151,14 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
         return result
 
     # VIEWS functionality
+    @time_limit_exceeded_handler
     def get_views(self, context_id: str) -> List[str]:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_views"])
         result = task_signature.delay(context_id=context_id).get(self._task_timeout)
         return result
 
     # TODO: this is very specific to mip, very inconsistent with the rest, has to be abstracted somehow
+    @time_limit_exceeded_handler
     def create_pathology_view(
         self,
         context_id: str,
@@ -142,11 +182,13 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
         return result
 
     # MERGE TABLES functionality
+    @time_limit_exceeded_handler
     def get_merge_tables(self, context_id: str) -> List[str]:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_merge_tables"])
         result = task_signature.delay(context_id=context_id).get(self._task_timeout)
         return result
 
+    @time_limit_exceeded_handler
     def create_merge_table(
         self, context_id: str, command_id: str, table_names: List[str]
     ):
@@ -161,12 +203,14 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
         return result
 
     # REMOTE TABLES functionality
+    @time_limit_exceeded_handler
     def get_remote_tables(self, context_id: str) -> List["TableInfo"]:
         task_signature = self._celery_app.signature(
             TASK_SIGNATURES["get_remote_tables"]
         )
-        return task_signature.delay(context_id=context_id)
+        return task_signature.delay(context_id=context_id).get(self._task_timeout)
 
+    @time_limit_exceeded_handler
     def create_remote_table(self, table_info: TableInfo, original_db_url: str) -> str:
         table_info_json = table_info.json()
         task_signature = self._celery_app.signature(
@@ -185,9 +229,9 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
         func_name: str,
         positional_args,
         keyword_args,
-    ) -> "AsyncResult":  #: positional_args: List[TableName or str]
+    ) -> QueueUDFAsyncResult:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["run_udf"])
-        return task_signature.delay(
+        async_result = task_signature.delay(
             command_id=command_id,
             context_id=context_id,
             func_name=func_name,
@@ -195,12 +239,31 @@ class NodeTasksHandlerCelery(INodeTasksHandler):
             keyword_args_json=keyword_args,
         )
 
+        return QueueUDFAsyncResult(
+            command_id=command_id,
+            context_id=context_id,
+            func_name=func_name,
+            positional_args=positional_args,
+            keyword_args=keyword_args,
+            async_result=async_result,
+        )
+
+    @time_limit_exceeded_handler
+    def get_queued_udf_result(self, async_result: QueueUDFAsyncResult):
+        return async_result.get(self._task_timeout)
+
+    @time_limit_exceeded_handler
+    def get_udf(self, algorithm_name) -> List[str]:
+        pass
+
+    @time_limit_exceeded_handler
     def get_udfs(self, algorithm_name) -> List[str]:
         task_signature = self._celery_app.signature(TASK_SIGNATURES["get_udfs"])
         result = task_signature.delay(algorithm_name).get(self._task_timeout)
         return result
 
     # return the generated monetdb pythonudf
+    @time_limit_exceeded_handler
     def get_run_udf_query(
         self,
         context_id: str,

--- a/mipengine/controller/node_tasks_handler_interface.py
+++ b/mipengine/controller/node_tasks_handler_interface.py
@@ -1,9 +1,26 @@
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Final
+from pydantic import BaseModel
+from typing import List, Tuple, Final, Any
 
 from mipengine.node_tasks_DTOs import TableData
 from mipengine.node_tasks_DTOs import TableSchema
 from mipengine.node_tasks_DTOs import TableInfo
+
+
+class IAsyncResult(BaseModel, ABC):
+    async_result: Any
+
+    @abstractmethod
+    def get(self, timeout=None):
+        pass
+
+
+class IQueueUDFAsyncResult(IAsyncResult):
+    command_id: str
+    context_id: str
+    func_name: str
+    positional_args: list
+    keyword_args: dict
 
 
 class INodeTasksHandler(ABC):
@@ -88,7 +105,11 @@ class INodeTasksHandler(ABC):
         func_name: str,
         positional_args,
         keyword_args,
-    ) -> "AsyncResult":  #: positional_args: List[TableName or str]
+    ) -> IQueueUDFAsyncResult:
+        pass
+
+    @abstractmethod
+    def get_queued_udf_result(self, async_result: IQueueUDFAsyncResult):
         pass
 
     @abstractmethod
@@ -97,7 +118,6 @@ class INodeTasksHandler(ABC):
 
     # return the generated monetdb pythonudf
     @abstractmethod
-    # TODO not sure wtf format positional_args should be
     def get_run_udf_query(
         self,
         context_id: str,

--- a/tasks.py
+++ b/tasks.py
@@ -401,11 +401,15 @@ def start_node(c, node=None, all_=False, celery_log_level=None, detached=False):
             if detached or all_:
                 cmd = (
                     f"PYTHONPATH={PROJECT_ROOT} poetry run celery "
-                    f"-A mipengine.node.node worker -l {celery_log_level} >> {outpath} 2>&1"
+                    f"-A mipengine.node.node worker -l {celery_log_level} >> {outpath} "
+                    f"--purge 2>&1"
                 )
                 run(c, cmd, wait=False)
             else:
-                cmd = f"PYTHONPATH={PROJECT_ROOT} poetry run celery -A mipengine.node.node worker -l {celery_log_level}"
+                cmd = (
+                    f"PYTHONPATH={PROJECT_ROOT} poetry run celery -A "
+                    f"mipengine.node.node worker -l {celery_log_level} --purge"
+                )
                 run(c, cmd, attach_=True)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -124,14 +124,10 @@ def create_configs(c):
     # Create the controller config file
     with open(CONTROLLER_CONFIG_TEMPLATE_FILE) as fp:
         template_controller_config = toml.load(fp)
-
     controller_config = template_controller_config.copy()
     controller_config["cdes_metadata_path"] = deployment_config["cdes_metadata_path"]
     controller_config["node_registry_update_interval"] = deployment_config[
         "node_registry_update_interval"
-    ]
-    controller_config["celery_tasks_timeout"] = deployment_config[
-        "celery_tasks_timeout"
     ]
 
     controller_config["deployment_type"] = "LOCAL"

--- a/tests/integration_tests/test_node_tasks_handler_celery.py
+++ b/tests/integration_tests/test_node_tasks_handler_celery.py
@@ -2,21 +2,19 @@ import pytest
 
 import json
 import toml
-import sys
 from os import path, listdir
 from pathlib import Path
 from typing import List, Final
 
-from mipengine.controller import config as controller_config
-from mipengine.controller.node_tasks_handler_celery import (
-    NodeTasksHandlerCelery,
-    CeleryParamsDTO,
-)
+from mipengine.controller.node_tasks_handler_celery import NodeTasksHandlerCelery
+from mipengine.controller.node_tasks_handler_celery import CeleryParamsDTO
 
 from mipengine.node_tasks_DTOs import TableSchema, ColumnInfo
 from mipengine import DType
 
-from pathlib import Path
+from mipengine import AttrDict
+from tasks import CONTROLLER_CONFIG_DIR
+
 import mipengine
 
 PROJECT_ROOT = Path(mipengine.__file__).parent.parent
@@ -43,6 +41,9 @@ def node_task_handler():
     if not a_localnode_config_file:
         pytest.fail(f"Config file for localnode was not found in {NODES_CONFIG_DIR}")
 
+    with open(CONTROLLER_CONFIG_DIR / "controller.toml") as fp:
+        controller_config = AttrDict(toml.load(fp))
+        
     celery_params_dto = None
     with open(a_localnode_config_file) as fp:
         tmp = toml.load(fp)
@@ -63,7 +64,7 @@ def node_task_handler():
             interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
             interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
             interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
-            tasks_timeout=controller_config.celery_tasks_timeout,
+            tasks_timeout=controller_config.rabbitmq.celery_tasks_timeout,
 
         )
 

--- a/tests/integration_tests/test_node_tasks_handler_celery.py
+++ b/tests/integration_tests/test_node_tasks_handler_celery.py
@@ -63,6 +63,8 @@ def node_task_handler():
             interval_start=controller_config.rabbitmq.celery_tasks_interval_start,
             interval_step=controller_config.rabbitmq.celery_tasks_interval_step,
             interval_max=controller_config.rabbitmq.celery_tasks_interval_max,
+            tasks_timeout=controller_config.celery_tasks_timeout,
+
         )
 
     return NodeTasksHandlerCelery(node_id=node_id, celery_params=celery_params_dto)


### PR DESCRIPTION
There are roughly 2 types of exceptions that can be raised when a (celery)task takes more time to finish than a defined time limit. The first type is controlled by a time limit set on the executing end, aka the node and the second type is controlled by a time limit set on the calling end, aka the controller/algorithm executor.

The first type, (controlled by the executing end, the node) are of `SoftTimeLimitExceeded` or `TimeLimitExceeded` type.
A `SoftTimeLimitExceeded` is raised when the task has not finished executing after the time limit defined as `celery.conf.task_soft_time_limit` (in `mipengine/node/node.py`). When this time limit is exceeded a `SoftTimeLimitExceeded` will be raised (and propagated to the caller who queued the task) but the worker running the task will not terminate the task execution, the task execution will continue to execute, it kind of serves as a warning.
A `TimeLimitExceeded` is raised when the task has not finished executing after the time limit defined as `celery.conf.task_time_limit` (in `mipengine/node/node.py`). When this time limit is exceeded, a `TimeLimitExceeded` will be raised (and propagated to the caller who queued the task) and the worker running the task will terminate the task execution.

The second type, (controlled by the caller end, controller/algorithm executor) is of `TimeoutError` type. It is raised when the code is blocked on a call to the `get` method waiting for the result of the task.

So in general, the way this works is that when the `get()` method is called without arguments a `SoftTimeLimit` or `TimeLimitExceeded` can be raised and if the `get(timeout)` method is called with a `timeout` argument then it is possible for a `TimeoutError` to be raised as well.
