### PR TITLE
Fix/mip 488/dynamic custom/framework log levels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -451,5 +451,14 @@ jobs:
         with:
           time: '120s' #https://team-1617704806227.atlassian.net/browse/MIP-248
 
+      - name: Controller logs
+        run: kubectl logs deployment/mipengine-controller-deployment
+
+      - name: Globalnode logs
+        run: kubectl logs deployment/mipengine-globalnode-deployment -c node
+
+      - name: Localnode logs
+        run: kubectl logs deployment/mipengine-localnode-deployment -c node
+
       - name: Run production env tests
         run: poetry run pytest tests/prod_env_tests

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
    ```
    ip = "172.17.0.1"
    log_level = "INFO"
-   celery_log_level ="INFO"
+   framework_log_level ="INFO"
    monetdb_image = "madgik/mipenginedb:latest"
    rabbitmq_image = "madgik/mipengine_rabbitmq:latest"
 

--- a/kubernetes/templates/mipengine-controller.yaml
+++ b/kubernetes/templates/mipengine-controller.yaml
@@ -26,6 +26,10 @@ spec:
         - mountPath: /opt/data
           name: metadata
         env:
+        - name: LOG_LEVEL
+          value: {{ .Values.log_level }}
+        - name: FRAMEWORK_LOG_LEVEL
+          value: {{ .Values.framework_log_level }}
         - name: DEPLOYMENT_TYPE
           value: "KUBERNETES"
         - name: NODE_REGISTRY_UPDATE_INTERVAL

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -50,7 +50,9 @@ spec:
         - name: NODE_ROLE
           value: "GLOBALNODE"
         - name: LOG_LEVEL
-          value: "INFO"
+          value: {{ .Values.log_level }}
+        - name: FRAMEWORK_LOG_LEVEL
+          value: {{ .Values.framework_log_level }}
         - name: RABBITMQ_IP
           valueFrom:
             fieldRef:

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -62,7 +62,9 @@ spec:
         - name: NODE_ROLE
           value: "LOCALNODE"
         - name: LOG_LEVEL
-          value: "INFO"
+          value: {{ .Values.log_level }}
+        - name: FRAMEWORK_LOG_LEVEL
+          value: {{ .Values.framework_log_level }}
         - name: RABBITMQ_IP
           valueFrom:
             fieldRef:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -3,7 +3,7 @@ mipengine_images:
   version: latest
 
 log_level: DEBUG
-framework_log_level: DEBUG
+framework_log_level: INFO
 
 cdes_path: /opt/data
 

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -2,7 +2,7 @@ mipengine_images:
   repository: madgik
   version: latest
 
-log_level: DEBUG
+log_level: INFO
 framework_log_level: INFO
 
 cdes_path: /opt/data

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -2,6 +2,9 @@ mipengine_images:
   repository: madgik
   version: latest
 
+log_level: DEBUG
+framework_log_level: DEBUG
+
 cdes_path: /opt/data
 
 monetdb_storage: /opt/monetdb

--- a/mipengine/controller/README.md
+++ b/mipengine/controller/README.md
@@ -8,10 +8,27 @@ To build a new image you must be on the project root `MIP-Engine`, then
 docker build -t <USERNAME>/mipengine_controller:<IMAGETAG> -f mipengine/controller/Dockerfile .
 ```
 
-## Run
+## Run with env file
 
-Then run the following command with your own env variables:
+Create a file with the nodes' locations, for example:
 
 ```
-docker run -d --name controller -p 5000:5000 -e NODE_REGISTRY_IP=172.17.0.1 -e NODE_REGISTRY_PORT=8500 hbpmip/mipengine_controller:0.1
+["172.17.0.1:5670", "172.17.0.1:5671", "172.17.0.1:5672"]
+```
+
+Create an env_file with the following variables:
+
+```
+LOG_LEVEL=INFO
+FRAMEWORK_LOG_LEVEL=INFO
+CDES_METADATA_PATH=172.17.0.1
+DEPLOYMENT_TYPE=LOCAL
+NODE_REGISTRY_UPDATE_INTERVAL=30
+LOCALNODES_CONFIG_FILE=/home/user/localnodes_config.json
+```
+
+Then start the container with:
+
+```
+docker run -d --name <CONTAINER_NAME> --env-file=.env_file <USERNAME>/mipengine_controller:<IMAGETAG>
 ```

--- a/mipengine/controller/__init__.py
+++ b/mipengine/controller/__init__.py
@@ -1,12 +1,9 @@
-import logging
 import os
 from enum import Enum
 from enum import unique
 from importlib.resources import open_text
-from logging.config import dictConfig
 
 import envtoml
-from quart.logging import serving_handler
 
 from mipengine import AttrDict
 from mipengine import controller

--- a/mipengine/controller/__init__.py
+++ b/mipengine/controller/__init__.py
@@ -24,35 +24,3 @@ if config_file := os.getenv("MIPENGINE_CONTROLLER_CONFIG_FILE"):
 else:
     with open_text(controller, "config.toml") as fp:
         config = AttrDict(envtoml.load(fp))
-
-dictConfig(
-    {
-        "version": 1,
-        "formatters": {
-            "controller_background_service_frm": {
-                "format": "%(asctime)s - %(levelname)s - CONTROLLER - BACKGROUND - %(module)s - %(funcName)s(%(lineno)d) - %(message)s",
-            },
-        },
-        "handlers": {
-            "controller_background_service_hdl": {
-                "level": config.log_level,
-                "formatter": "controller_background_service_frm",
-                "class": "logging.StreamHandler",
-                "stream": "ext://sys.stdout",
-            },
-        },
-        "loggers": {
-            "controller_background_service": {
-                "level": config.log_level,
-                "handlers": ["controller_background_service_hdl"],
-            },
-            "quart.serving": {
-                "level": config.framework_log_level,
-            },
-        },
-    }
-)
-
-serving_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(levelname)s - CONTROLLER - WEBAPI - %(message)s")
-)

--- a/mipengine/controller/__init__.py
+++ b/mipengine/controller/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from enum import Enum
 from enum import unique
@@ -5,6 +6,7 @@ from importlib.resources import open_text
 from logging.config import dictConfig
 
 import envtoml
+from quart.logging import serving_handler
 
 from mipengine import AttrDict
 from mipengine import controller
@@ -44,6 +46,13 @@ dictConfig(
                 "level": config.log_level,
                 "handlers": ["controller_background_service_hdl"],
             },
+            "quart.serving": {
+                "level": config.framework_log_level,
+            },
         },
     }
+)
+
+serving_handler.setFormatter(
+    logging.Formatter("%(asctime)s - %(levelname)s - CONTROLLER - WEBAPI - %(message)s")
 )

--- a/mipengine/controller/api/app.py
+++ b/mipengine/controller/api/app.py
@@ -1,8 +1,4 @@
-import logging
-
-
 from quart import Quart
-from quart.logging import serving_handler
 
 from mipengine.controller.api.algorithms_endpoint import algorithms
 from mipengine.controller.api.error_handlers import error_handlers
@@ -10,7 +6,3 @@ from mipengine.controller.api.error_handlers import error_handlers
 app = Quart(__name__)
 app.register_blueprint(algorithms)
 app.register_blueprint(error_handlers)
-
-serving_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(levelname)s - CONTROLLER - WEBAPI - %(message)s")
-)

--- a/mipengine/controller/api/app.py
+++ b/mipengine/controller/api/app.py
@@ -1,8 +1,49 @@
-from quart import Quart
+import logging
+from logging.config import dictConfig
 
+from quart import Quart
+from quart.logging import serving_handler
+
+from mipengine.controller import config as ctrl_config
 from mipengine.controller.api.algorithms_endpoint import algorithms
 from mipengine.controller.api.error_handlers import error_handlers
 
 app = Quart(__name__)
 app.register_blueprint(algorithms)
 app.register_blueprint(error_handlers)
+
+
+# The initialization of the loggers is inside the app file because we don't want to initialize them
+# from the tests since there is no config available then.
+# We only want to intialize the loggers when the quart app is started.
+dictConfig(
+    {
+        "version": 1,
+        "formatters": {
+            "controller_background_service_frm": {
+                "format": "%(asctime)s - %(levelname)s - CONTROLLER - BACKGROUND - %(module)s - %(funcName)s(%(lineno)d) - %(message)s",
+            },
+        },
+        "handlers": {
+            "controller_background_service_hdl": {
+                "level": ctrl_config.log_level,
+                "formatter": "controller_background_service_frm",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "controller_background_service": {
+                "level": ctrl_config.log_level,
+                "handlers": ["controller_background_service_hdl"],
+            },
+            "quart.serving": {
+                "level": ctrl_config.framework_log_level,
+            },
+        },
+    }
+)
+
+serving_handler.setFormatter(
+    logging.Formatter("%(asctime)s - %(levelname)s - CONTROLLER - WEBAPI - %(message)s")
+)

--- a/mipengine/controller/config.toml
+++ b/mipengine/controller/config.toml
@@ -1,4 +1,6 @@
-log_level = "INFO"
+log_level = "$LOG_LEVEL"
+framework_log_level = "$FRAMEWORK_LOG_LEVEL"
+
 cdes_metadata_path = "$CDES_METADATA_PATH"
 
 deployment_type="$DEPLOYMENT_TYPE"

--- a/mipengine/node/README.md
+++ b/mipengine/node/README.md
@@ -8,14 +8,6 @@ To build a new image you must be on the project root `MIP-Engine`, then
 docker build -t <USERNAME>/mipengine_node:<IMAGETAG> -f mipengine/node/Dockerfile .
 ```
 
-## Run
-
-Then run the following command with your own env variables:
-
-```
-docker run -d --name globalnode -e NODE_IDENTIFIER=globalnode -e NODE_ROLE=GLOBALNODE -e LOG_LEVEL=INFO -e NODE_REGISTRY_IP=172.17.0.1 -e NODE_REGISTRY_PORT=8500 -e RABBITMQ_IP=172.17.0.1 -e RABBITMQ_PORT=5670 -e MONETDB_IP=172.17.0.1 -e MONETDB_PORT=50000 hbpmip/mipengine_node:0.1
-```
-
 ## Run with env file
 
 Create an env_file with the following variables:
@@ -24,8 +16,7 @@ Create an env_file with the following variables:
 NODE_IDENTIFIER=globalnode
 NODE_ROLE=GLOBALNODE
 LOG_LEVEL=INFO
-NODE_REGISTRY_IP=172.17.0.1
-NODE_REGISTRY_PORT=8500
+FRAMEWORK_LOG_LEVEL=INFO
 RABBITMQ_IP=172.17.0.1
 RABBITMQ_PORT=5670
 MONETDB_IP=172.17.0.1
@@ -35,5 +26,5 @@ MONETDB_PORT=50000
 Then start the container with:
 
 ```
-docker run -d --name <CONTAINER_NAME> --env-file=.env_file hbpmip/mipengine_node:0.1
+docker run -d --name <CONTAINER_NAME> --env-file=.env_file <USERNAME>/mipengine_node:<IMAGETAG>
 ```

--- a/mipengine/node/config.toml
+++ b/mipengine/node/config.toml
@@ -1,6 +1,8 @@
 identifier = "$NODE_IDENTIFIER"
-log_level = "$LOG_LEVEL"
 role = "$NODE_ROLE"
+
+log_level = "$LOG_LEVEL"
+framework_log_level = "$FRAMEWORK_LOG_LEVEL"
 
 cdes_metadata_path = "./tests/demo_data"
 

--- a/mipengine/node/node.py
+++ b/mipengine/node/node.py
@@ -36,7 +36,7 @@ def setup_celery_logging(*args, **kwargs):
     sh.setFormatter(formatter)
     logger.addHandler(sh)
 
-    logger.setLevel(node_config.log_level)
+    logger.setLevel(node_config.framework_log_level)
 
 
 celery.conf.worker_concurrency = node_config.celery.worker_concurrency

--- a/tests/dev_env_tests/deployment_template.toml
+++ b/tests/dev_env_tests/deployment_template.toml
@@ -1,6 +1,6 @@
 ip = "172.17.0.1"
 log_level = "INFO"
-celery_log_level ="INFO"
+framework_log_level ="INFO"
 monetdb_image = "madgik/mipenginedb:latest"
 rabbitmq_image = "madgik/mipengine_rabbitmq:latest"
 

--- a/tests/prod_env_tests/kubernetes_values.yaml
+++ b/tests/prod_env_tests/kubernetes_values.yaml
@@ -2,6 +2,9 @@ mipengine_images:
   repository: madgik
   version: latest
 
+log_level: DEBUG
+framework_log_level: INFO
+
 cdes_path: /opt/data
 
 monetdb_storage: /opt/monetdb


### PR DESCRIPTION
Changelog:
  - Added log_level and framework_log_level to node/controller services.
  - Setting both of them from the .deployment.toml for development.
  - Setting both of them from helm values for kubernetes deployment.
  - Updated node/controller README with new env variables.