### PR TITLE
Algorithm imports refactored.

### DIFF
--- a/mipengine/__init__.py
+++ b/mipengine/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     "AttrDict",
     "ALGORITHM_FOLDERS_ENV_VARIABLE",
     "ALGORITHM_FOLDERS",
-    "import_algorithm_modules",
+    "algorithm_modules",
 ]
 
 ALGORITHM_FOLDERS_ENV_VARIABLE = "ALGORITHM_FOLDERS"
@@ -61,3 +61,6 @@ def import_algorithm_modules() -> Dict[str, ModuleType]:
         all_modules.update(modules)
 
     return all_modules
+
+
+algorithm_modules = import_algorithm_modules()

--- a/mipengine/controller/algorithm_executor.py
+++ b/mipengine/controller/algorithm_executor.py
@@ -11,7 +11,7 @@ from billiard.exceptions import TimeLimitExceeded
 from celery.exceptions import TimeoutError
 from pydantic import BaseModel
 
-from mipengine import import_algorithm_modules
+from mipengine import algorithm_modules
 from mipengine.controller import controller_logger as ctrl_logger
 from mipengine.controller.algorithm_execution_DTOs import AlgorithmExecutionDTO
 from mipengine.controller.algorithm_execution_DTOs import NodesTasksHandlersDTO
@@ -25,8 +25,6 @@ from mipengine.node_tasks_DTOs import TableData
 from mipengine.node_tasks_DTOs import TableSchema
 from mipengine.node_tasks_DTOs import UDFArgument
 from mipengine.node_tasks_DTOs import UDFArgumentKind
-
-algorithm_modules = import_algorithm_modules()
 
 
 class _TableName:

--- a/mipengine/node/tasks/udfs.py
+++ b/mipengine/node/tasks/udfs.py
@@ -19,9 +19,6 @@ from mipengine.udfgen import generate_udf_queries
 from mipengine.udfgen.udfgenerator import udf as udf_registry
 
 
-import_algorithm_modules()
-
-
 @shared_task
 @initialise_logger
 def get_udf(func_name: str) -> str:

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -1359,10 +1359,6 @@ class UDFDecorator:
             funcparts = breakup_function(func, signature)
             validate_udf_table_input_types(funcparts.table_input_types)
             funcname = funcparts.qualname
-            if funcname in self.registry:
-                raise UDFBadDefinition(
-                    f"A function named {funcname} is already in the udf registry."
-                )
             self.registry[funcname] = funcparts
             return func
 

--- a/tests/standalone_tests/test_udfgenerator.py
+++ b/tests/standalone_tests/test_udfgenerator.py
@@ -466,22 +466,6 @@ def test_state_schema():
     assert to.schema == [("state", DType.BINARY)]
 
 
-def test_udf_decorator_already_there():
-    @udf(return_type=scalar(int))
-    def already_there():
-        x = 1
-        return x
-
-    with pytest.raises(UDFBadDefinition) as exc:
-
-        @udf(return_type=scalar(int))
-        def already_there():
-            x = 1
-            return x
-
-    assert "already in the udf registry" in str(exc)
-
-
 def test_convert_udfgenargs_to_udfargs_relation():
     udfgen_posargs = [
         TableInfo(


### PR DESCRIPTION
Changelog:
  - Algorthms are imported in the __init__ of mipengine.
  - UFGenerator no longer checks for methods already in udf registry. This is no longer needed since a method name contains the module as well.