### PR TITLE
Logistic Regression now uses RelationType instead of Scalar.

### DIFF
--- a/mipengine/algorithms/logistic_regression.py
+++ b/mipengine/algorithms/logistic_regression.py
@@ -119,8 +119,8 @@ def run(algo_interface):
             func_name=make_unique_func_name(logistic_loss),
             keyword_args={"v1": y, "v2": s},
         )
-
-        newlogloss = sum(newlogloss.get_table_data())
+        # TODO local_run results should not be fetched https://team-1617704806227.atlassian.net/browse/MIP-534
+        newlogloss = sum(newlogloss.get_table_data()[1])
 
         # ~~~~~~~~ Global part ~~~~~~~~ #
         hessian_global = global_run(
@@ -236,7 +236,7 @@ def diag(vec):
     return result
 
 
-@udf(v1=tensor(T, N), v2=tensor(T, N), return_type=scalar(float))
+@udf(v1=tensor(T, N), v2=tensor(T, N), return_type=relation(schema=[("scalar", float)]))
 def logistic_loss(v1, v2):
     from scipy import special
 
@@ -244,7 +244,7 @@ def logistic_loss(v1, v2):
     return ll
 
 
-@udf(t1=tensor(T, N), t2=tensor(T, N), return_type=scalar(float))
+@udf(t1=tensor(T, N), t2=tensor(T, N), return_type=relation(schema=[("scalar", float)]))
 def tensor_max_abs_diff(t1, t2):
     result = numpy.max(numpy.abs(t1 - t2))
     return result

--- a/mipengine/controller/algorithm_flow_data_objects.py
+++ b/mipengine/controller/algorithm_flow_data_objects.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC
 from typing import Any
 from typing import Dict
@@ -77,17 +78,25 @@ class LocalNodesTable(LocalNodesData):
         return node.get_table_schema(table)
 
     def get_table_data(self) -> List[Union[int, float, str]]:
+        """
+        Should be used ONLY for debugging.
+        """
+        warnings.warn(
+            "'get_table_data' of 'LocalNodesTable' should not be used in production."
+        )
+
         tables_data = []
         for node, table_name in self.nodes_tables.items():
-            tables_data.append(node.get_table_data(table_name))
-        tables_data_flat = [table_data.columns for table_data in tables_data]
-        tables_data_flat = [
-            elem
-            for table in tables_data_flat
-            for column in table
-            for elem in column.data
-        ]
-        return tables_data_flat
+            tables_data.append(node.get_table_data(table_name).columns)
+
+        merged_table_data = []
+        for table in tables_data:
+            for index, column in enumerate(table):
+                if len(merged_table_data) <= index:
+                    merged_table_data.append(column.data)
+                else:
+                    merged_table_data[index].extend(column.data)
+        return merged_table_data
 
     def __repr__(self):
         r = f"\n\tLocalNodeTable: {self.get_table_schema()}\n"

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -846,11 +846,20 @@ def relation(schema):
 
 
 class ScalarType(OutputType, ParametrizedType):
+    """
+    @deprecated
+    Use 'RelationType(schema=[("scalar", dtype)])' instead.
+    """
+
     def __init__(self, dtype):
         self.dtype = dt.from_py(dtype) if isinstance(dtype, type) else dtype
 
 
 def scalar(dtype):
+    """
+    @deprecated
+    Use 'relation(schema=[("scalar", dtype)])' instead.
+    """
     return ScalarType(dtype)
 
 

--- a/mipengine/udfgen/udfio.py
+++ b/mipengine/udfgen/udfio.py
@@ -60,11 +60,17 @@ def from_tensor_table(table: dict):
     return np.array(array)
 
 
-def as_relational_table(array: np.ndarray, name: str):
-    assert len(array.shape) in (1, 2)
-    names = (f"{name}_{i}" for i in range(array.shape[1]))
-    out = {n: c for n, c in zip(names, array)}
-    return out
+def as_relational_table(array: np.ndarray):
+    """
+    TODO Output of relational tables needs to be refactored
+    What objects can we return? Do we need a name parameter?
+    https://team-1617704806227.atlassian.net/browse/MIP-536
+
+    """
+    # assert len(array.shape) in (1, 2)
+    # names = (f"{name}_{i}" for i in range(array.shape[1]))
+    # out = {n: c for n, c in zip(names, array)}
+    return array
 
 
 def reduce_tensor_pair(op, a: pd.DataFrame, b: pd.DataFrame):


### PR DESCRIPTION
Changelog:
  - `ScalarType` usages removed from logistic regression. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-426)
  - `LocalNodesTable.get_table_data` refactored to return the data per column.
  - `udfio.as_relational_table` refactored to return the data without changes. More work needed.