### PR TITLE
Fix for using 'dev' images in development, instead of 'latest'.

### DIFF
--- a/.github/workflows/prod_env_tests.yml
+++ b/.github/workflows/prod_env_tests.yml
@@ -55,7 +55,7 @@ jobs:
           file: monetdb/Dockerfile
           push: false
           load: true
-          tags: madgik/mipenginedb:latest
+          tags: madgik/mipenginedb:dev
           cache-from: type=local,src=/tmp/.buildx-cache/monetdb
           cache-to: type=local,dest=/tmp/.buildx-cache-new/monetdb
 
@@ -74,7 +74,7 @@ jobs:
           file: mipdb/Dockerfile
           push: false
           load: true
-          tags: madgik/mipengine_mipdb:latest
+          tags: madgik/mipengine_mipdb:dev
           cache-from: type=local,src=/tmp/.buildx-cache/mipdb
           cache-to: type=local,dest=/tmp/.buildx-cache-new/mipdb
 
@@ -93,7 +93,7 @@ jobs:
           file: rabbitmq/Dockerfile
           push: false
           load: true
-          tags: madgik/mipengine_rabbitmq:latest
+          tags: madgik/mipengine_rabbitmq:dev
           cache-from: type=local,src=/tmp/.buildx-cache/rabbitmq
           cache-to: type=local,dest=/tmp/.buildx-cache-new/rabbitmq
 
@@ -112,7 +112,7 @@ jobs:
           file: mipengine/node/Dockerfile
           push: false
           load: true
-          tags: madgik/mipengine_node:latest
+          tags: madgik/mipengine_node:dev
           cache-from: type=local,src=/tmp/.buildx-cache/node
           cache-to: type=local,dest=/tmp/.buildx-cache-new/node
 
@@ -131,7 +131,7 @@ jobs:
           file: mipengine/controller/Dockerfile
           push: false
           load: true
-          tags: madgik/mipengine_controller:latest
+          tags: madgik/mipengine_controller:dev
           cache-from: type=local,src=/tmp/.buildx-cache/controller
           cache-to: type=local,dest=/tmp/.buildx-cache-new/controller
 
@@ -177,11 +177,11 @@ jobs:
 
       - name: Load docker images to kind
         run: |
-          kind load docker-image madgik/mipengine_node:latest
-          kind load docker-image madgik/mipengine_controller:latest --nodes kind-control-plane
-          kind load docker-image madgik/mipenginedb:latest
-          kind load docker-image madgik/mipengine_mipdb:latest
-          kind load docker-image madgik/mipengine_rabbitmq:latest
+          kind load docker-image madgik/mipengine_node:dev
+          kind load docker-image madgik/mipengine_controller:dev --nodes kind-control-plane
+          kind load docker-image madgik/mipenginedb:dev
+          kind load docker-image madgik/mipengine_mipdb:dev
+          kind load docker-image madgik/mipengine_rabbitmq:dev
 
       - name: Copy prod_env_tests values.yaml
         run: cp -r tests/prod_env_tests/deployment_configs/kubernetes_values.yaml kubernetes/values.yaml

--- a/.github/workflows/publish_dev_images.yml
+++ b/.github/workflows/publish_dev_images.yml
@@ -1,0 +1,212 @@
+name: Publish DEV images
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_and_push_monetdb:
+    name: Build MONETDB image and push to dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Load MONETDB cached image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache/monetdb
+          key: ${{ runner.os }}-buildx-monetdb-${{hashFiles( 'monetdb/**' )}}
+          restore-keys: |
+            ${{ runner.os }}-buildx-monetdb-
+      - name: Build and Push MONETDB docker image to dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: monetdb/Dockerfile
+          push: true
+          tags: madgik/mipenginedb:dev
+          cache-from: type=local,src=/tmp/.buildx-cache/monetdb
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/monetdb
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move Docker images cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build_and_push_mipdb:
+    name: Build MIPDB container image and push to dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Load MIPDB cached image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache/mipdb
+          key: ${{ runner.os }}-buildx-mipdb-${{hashFiles( 'mipdb/**' )}}
+          restore-keys: |
+            ${{ runner.os }}-buildx-mipdb-
+      - name: Build and Push MIPDB docker image to dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: mipdb/Dockerfile
+          push: true
+          tags: madgik/mipengine_mipdb:dev
+          cache-from: type=local,src=/tmp/.buildx-cache/mipdb
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/mipdb
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move Docker images cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build_and_push_rabbitmq:
+    name: Build RABBITMQ image and push to dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Load RABBITMQ cached image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache/rabbitmq
+          key: ${{ runner.os }}-buildx-rabbitmq-${{hashFiles( 'rabbitmq/**' )}}
+          restore-keys: |
+            ${{ runner.os }}-buildx-rabbitmq-
+      - name: Build RABBITMQ docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: rabbitmq/Dockerfile
+          push: true
+          tags: madgik/mipengine_rabbitmq:dev
+          cache-from: type=local,src=/tmp/.buildx-cache/rabbitmq
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/rabbitmq
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move Docker images cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build_and_push_controller:
+    name: Build CONTROLLER image and push to dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Load CONTROLLER service cached image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache/controller
+          key: ${{ runner.os }}-buildx-controller-${{hashFiles('mipengine/**')}}
+          restore-keys: |
+            ${{ runner.os }}-buildx-controller-
+      - name: Build CONTROLLER service docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: mipengine/controller/Dockerfile
+          push: true
+          tags: madgik/mipengine_controller:dev
+          cache-from: type=local,src=/tmp/.buildx-cache/controller
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/controller
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move Docker images cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  build_and_push_node:
+    name: Build NODE image and push to dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Load NODE service cached image
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache/node
+          key: ${{ runner.os }}-buildx-node-${{hashFiles('mipengine/**')}}
+          restore-keys: |
+            ${{ runner.os }}-buildx-node-
+      - name: Build NODE service docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: mipengine/node/Dockerfile
+          push: true
+          tags: madgik/mipengine_node:dev
+          cache-from: type=local,src=/tmp/.buildx-cache/node
+          cache-to: type=local,dest=/tmp/.buildx-cache-new/node
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move Docker images cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/standalone_tests.yml
+++ b/.github/workflows/standalone_tests.yml
@@ -55,7 +55,7 @@ jobs:
           file: monetdb/Dockerfile
           push: false
           load: true
-          tags: madgik/mipenginedb:latest
+          tags: madgik/mipenginedb:dev
           cache-from: type=local,src=/tmp/.buildx-cache/monetdb
           cache-to: type=local,dest=/tmp/.buildx-cache-new/monetdb
 
@@ -74,7 +74,7 @@ jobs:
           file: rabbitmq/Dockerfile
           push: false
           load: true
-          tags: madgik/mipengine_rabbitmq:latest
+          tags: madgik/mipengine_rabbitmq:dev
           cache-from: type=local,src=/tmp/.buildx-cache/rabbitmq
           cache-to: type=local,dest=/tmp/.buildx-cache-new/rabbitmq
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@
    ip = "172.17.0.1"
    log_level = "INFO"
    framework_log_level ="INFO"
-   monetdb_image = "madgik/mipenginedb:latest"
-   rabbitmq_image = "madgik/mipengine_rabbitmq:latest"
+   monetdb_image = "madgik/mipenginedb:dev"
+   rabbitmq_image = "madgik/mipengine_rabbitmq:dev"
 
    algorithm_folders = "./mipengine/algorithms,./tests/algorithms"
 

--- a/tasks.py
+++ b/tasks.py
@@ -885,7 +885,7 @@ def get_docker_image(c, image, always_pull=False):
     cmd = f"docker images -q {image}"
     _, image_tag = image.split(":")
     result = run(c, cmd, show_ok=False)
-    if result.stdout != "" and image_tag != "latest":
+    if result.stdout != "" and image_tag != "latest" and image_tag != "dev":
         return
 
     message(f"Pulling image {image} ...", Level.HEADER)

--- a/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
+++ b/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
@@ -2,7 +2,7 @@ localnodes: 3
 
 mipengine_images:
   repository: madgik
-  version: latest
+  version: dev
 
 log_level: DEBUG
 framework_log_level: INFO

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -18,8 +18,8 @@ from mipengine.controller.node_tasks_handler_celery import NodeTasksHandlerCeler
 from mipengine.udfgen import udfio
 
 ALGORITHM_FOLDERS_ENV_VARIABLE_VALUE = "./mipengine/algorithms,./tests/algorithms"
-TESTING_RABBITMQ_CONT_IMAGE = "madgik/mipengine_rabbitmq:latest"
-TESTING_MONETDB_CONT_IMAGE = "madgik/mipenginedb:latest"
+TESTING_RABBITMQ_CONT_IMAGE = "madgik/mipengine_rabbitmq:dev"
+TESTING_MONETDB_CONT_IMAGE = "madgik/mipenginedb:dev"
 
 this_mod_path = os.path.dirname(os.path.abspath(__file__))
 TEST_ENV_CONFIG_FOLDER = path.join(this_mod_path, "testing_env_configs")


### PR DESCRIPTION
Changelog:
  - Fix for using 'dev' images in development, instead of 'latest'. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-580)


Explanation and solution:
The problem we had previously was that component version were never published other than production releases.

This meant that a developer would need to 1) build the images that he used in his current branch or 2) use the “latest” production releases.

In the 1st option it would mean more manual work and in the 2nd option, which we did now, before a monthly release components would slowly become out of date with the master branch.

The solution implemented was to:
  - Separate the “latest” tag that is used for production from a “dev” tag that we will use in development. So currently in the .deployment.toml all images have a “dev” tag.
  - When a PR is merged github actions run publishing all components to that “dev” tag, which means that the “dev” tag will always have the latest master merged versions.