### PR TITLE
MIP-588 cross validation prototype

### DIFF
--- a/mipengine/algorithms/linear_regression.py
+++ b/mipengine/algorithms/linear_regression.py
@@ -53,9 +53,8 @@ def run(executor):
     lr.fit(X=X, y=y)
     y_pred: RealVector = lr.predict(X)
     lr.compute_summary(
-        y_true=relation_to_vector(y, executor),
+        y_test=relation_to_vector(y, executor),
         y_pred=y_pred,
-        y_mean=lr.y_mean,
         p=p,
     )
 
@@ -98,20 +97,18 @@ class LinearRegression:
         )
         global_transfer_data = json.loads(self.global_transfer.get_table_data()[1][0])
         self.coefficients = global_transfer_data["coefficients"]
-        self.y_mean = global_transfer_data["y_mean"]
 
     @staticmethod
     @udf(x=relation(), y=relation(), return_type=[secure_transfer(sum_op=True)])
     def _fit_local(x, y):
         xTx = x.T @ x
         xTy = x.T @ y
-        sy = float(y.sum())
-        n_obs = len(y)
+        n_obs_train = len(y)
+
         stransfer = {}
         stransfer["xTx"] = {"data": xTx.to_numpy().tolist(), "operation": "sum"}
         stransfer["xTy"] = {"data": xTy.to_numpy().tolist(), "operation": "sum"}
-        stransfer["sy"] = {"data": sy, "operation": "sum"}
-        stransfer["n_obs"] = {"data": n_obs, "operation": "sum"}
+        stransfer["n_obs_train"] = {"data": n_obs_train, "operation": "sum"}
         return stransfer
 
     @staticmethod
@@ -122,20 +119,17 @@ class LinearRegression:
     def _fit_global(local_transfers):
         xTx = numpy.array(local_transfers["xTx"])
         xTy = numpy.array(local_transfers["xTy"])
-        sy = local_transfers["sy"]
-        n_obs = local_transfers["n_obs"]
+        n_obs_train = local_transfers["n_obs_train"]
 
         xTx_inv = numpy.linalg.pinv(xTx)
         coefficients = xTx_inv @ xTy
 
-        y_mean = sy / n_obs
-
         state_ = {}
         state_["xTx_inv"] = xTx_inv  # Needed for SE(β) calculation
+        state_["n_obs_train"] = n_obs_train
 
         transfer_ = {}
         transfer_["coefficients"] = coefficients.tolist()
-        transfer_["y_mean"] = y_mean
         return state_, transfer_
 
     def predict(self, X):
@@ -154,10 +148,10 @@ class LinearRegression:
         y_pred = x @ coefficients
         return y_pred
 
-    def compute_summary(self, y_true, y_pred, y_mean, p):
+    def compute_summary(self, y_test, y_pred, p):
         local_transfers = self.local_run(
             func=self._compute_summary_local,
-            keyword_args=dict(y_true=y_true, y_pred=y_pred, y_mean=y_mean),
+            keyword_args=dict(y_test=y_test, y_pred=y_pred),
             share_to_global=[True],
         )
         global_transfer = self.global_run(
@@ -169,11 +163,13 @@ class LinearRegression:
         global_transfer_data = json.loads(global_transfer.get_table_data()[1][0])
         rss = global_transfer_data["rss"]
         tss = global_transfer_data["tss"]
+        sum_abs_resid = global_transfer_data["sum_abs_resid"]
         xTx_inv = numpy.array(global_transfer_data["xTx_inv"])
         coefficients = numpy.array(self.coefficients)
-        n_obs = global_transfer_data["n_obs"]
-        df = n_obs - p - 1
-        self.n_obs = n_obs
+        n_obs_train = global_transfer_data["n_obs_train"]
+        n_obs_test = global_transfer_data["n_obs_test"]
+        df = n_obs_train - p - 1
+        self.n_obs = n_obs_train
         self.df = df
         self.rse = (rss / df) ** 0.5
         self.std_err = ((self.rse**2) * numpy.diag(xTx_inv)) ** 0.5
@@ -183,27 +179,33 @@ class LinearRegression:
             coefficients.T[0] + stats.t.ppf(1 - ALPHA / 2, df) * self.std_err,
         )
         self.r_squared = 1.0 - rss / tss
-        self.r_squared_adjusted = 1 - (1 - self.r_squared) * (n_obs - 1) / df
+        self.r_squared_adjusted = 1 - (1 - self.r_squared) * (n_obs_train - 1) / df
         self.f_stat = (tss - rss) * df / (p * rss)
         self.t_p_values = stats.t.sf(abs(self.t_stat), df=df) * 2
         self.f_p_value = stats.f.sf(self.f_stat, dfn=p, dfd=df)
+        # Quanities below are only used in cross validation
+        self.rmse = (rss / n_obs_test) ** 0.5
+        self.mae = sum_abs_resid / n_obs_test
 
     @staticmethod
     @udf(
-        y_true=RealVector,
+        y_test=RealVector,
         y_pred=RealVector,
-        y_mean=literal(),
         return_type=secure_transfer(sum_op=True),
     )
-    def _compute_summary_local(y_true, y_pred, y_mean):
-        rss = float(sum((y_true - y_pred) ** 2))
-        tss = float(sum((y_true - y_mean) ** 2))
-        n_obs = len(y_true)
+    def _compute_summary_local(y_test, y_pred):
+        rss = sum((y_test - y_pred) ** 2)
+        sum_y_test = sum(y_test)
+        sum_sq_y_test = sum(y_test**2)
+        sum_abs_resid = sum(abs(y_test - y_pred))
+        n_obs_test = len(y_test)
 
         stransfer = {}
-        stransfer["rss"] = {"data": rss, "operation": "sum"}
-        stransfer["tss"] = {"data": tss, "operation": "sum"}
-        stransfer["n_obs"] = {"data": n_obs, "operation": "sum"}
+        stransfer["rss"] = {"data": float(rss), "operation": "sum"}
+        stransfer["sum_y_test"] = {"data": float(sum_y_test), "operation": "sum"}
+        stransfer["sum_sq_y_test"] = {"data": float(sum_sq_y_test), "operation": "sum"}
+        stransfer["sum_abs_resid"] = {"data": float(sum_abs_resid), "operation": "sum"}
+        stransfer["n_obs_test"] = {"data": n_obs_test, "operation": "sum"}
         return stransfer
 
     @staticmethod
@@ -214,13 +216,26 @@ class LinearRegression:
     )
     def _compute_summary_global(fit_gstate, local_transfers):
         xTx_inv = fit_gstate["xTx_inv"]
-        n_obs = local_transfers["n_obs"]
+        n_obs_train = fit_gstate["n_obs_train"]
+        n_obs_test = local_transfers["n_obs_test"]
         rss = local_transfers["rss"]
-        tss = local_transfers["tss"]
+        sum_abs_resid = local_transfers["sum_abs_resid"]
+        sum_y_test = local_transfers["sum_y_test"]
+        sum_sq_y_test = local_transfers["sum_sq_y_test"]
+
+        y_mean_test = sum_y_test / n_obs_test
+
+        # Federated computation of TSS in a single round
+        # \sum_i (y_i - ymean)^2 = \sum_i yi^2 - 2 ymean \sum_i yi + n ymean^2
+        tss = (
+            sum_sq_y_test - 2 * y_mean_test * sum_y_test + n_obs_test * y_mean_test**2
+        )
 
         transfer_ = {}
         transfer_["rss"] = rss
         transfer_["tss"] = tss
-        transfer_["n_obs"] = n_obs
+        transfer_["sum_abs_resid"] = sum_abs_resid
+        transfer_["n_obs_train"] = n_obs_train
+        transfer_["n_obs_test"] = n_obs_test
         transfer_["xTx_inv"] = xTx_inv.tolist()
         return transfer_

--- a/mipengine/algorithms/linear_regression.py
+++ b/mipengine/algorithms/linear_regression.py
@@ -53,7 +53,7 @@ def run(executor):
     lr.fit(X=X, y=y)
     y_pred: RealVector = lr.predict(X)
     lr.compute_summary(
-        y=relation_to_vector(y, executor),
+        y_true=relation_to_vector(y, executor),
         y_pred=y_pred,
         y_mean=lr.y_mean,
         p=p,
@@ -132,7 +132,6 @@ class LinearRegression:
 
         state_ = {}
         state_["xTx_inv"] = xTx_inv  # Needed for SE(β) calculation
-        state_["n_obs"] = n_obs
 
         transfer_ = {}
         transfer_["coefficients"] = coefficients.tolist()
@@ -155,10 +154,10 @@ class LinearRegression:
         y_pred = x @ coefficients
         return y_pred
 
-    def compute_summary(self, y, y_pred, y_mean, p):
+    def compute_summary(self, y_true, y_pred, y_mean, p):
         local_transfers = self.local_run(
             func=self._compute_summary_local,
-            keyword_args=dict(y=y, y_pred=y_pred, y_mean=y_mean),
+            keyword_args=dict(y_true=y_true, y_pred=y_pred, y_mean=y_mean),
             share_to_global=[True],
         )
         global_transfer = self.global_run(
@@ -191,18 +190,20 @@ class LinearRegression:
 
     @staticmethod
     @udf(
-        y=RealVector,
+        y_true=RealVector,
         y_pred=RealVector,
         y_mean=literal(),
         return_type=secure_transfer(sum_op=True),
     )
-    def _compute_summary_local(y, y_pred, y_mean):
-        rss = float(sum((y - y_pred) ** 2))
-        tss = float(sum((y - y_mean) ** 2))
+    def _compute_summary_local(y_true, y_pred, y_mean):
+        rss = float(sum((y_true - y_pred) ** 2))
+        tss = float(sum((y_true - y_mean) ** 2))
+        n_obs = len(y_true)
 
         stransfer = {}
         stransfer["rss"] = {"data": rss, "operation": "sum"}
         stransfer["tss"] = {"data": tss, "operation": "sum"}
+        stransfer["n_obs"] = {"data": n_obs, "operation": "sum"}
         return stransfer
 
     @staticmethod
@@ -213,7 +214,7 @@ class LinearRegression:
     )
     def _compute_summary_global(fit_gstate, local_transfers):
         xTx_inv = fit_gstate["xTx_inv"]
-        n_obs = fit_gstate["n_obs"]
+        n_obs = local_transfers["n_obs"]
         rss = local_transfers["rss"]
         tss = local_transfers["tss"]
 

--- a/mipengine/algorithms/linear_regression_cv.json
+++ b/mipengine/algorithms/linear_regression_cv.json
@@ -1,0 +1,47 @@
+{
+    "name": "linear_regression_cv",
+    "desc": "Linear Regression Cross-validation",
+    "label": "Linear Regression Cross-validation",
+    "enabled": true,
+    "inputdata": {
+        "x": {
+            "label": "features",
+            "desc": "Features",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        },
+        "y": {
+            "label": "target",
+            "desc": "Target variable",
+            "types": [
+                "real"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        }
+    },
+    "parameters": {
+        "n_splits": {
+            "label": "Number of splits",
+            "desc": "Number of splits",
+            "type": "int",
+            "min": 2,
+            "max": 20,
+            "default": 5,
+            "notblank": true,
+            "multiple": false
+        }
+    }
+}

--- a/mipengine/algorithms/linear_regression_cv.py
+++ b/mipengine/algorithms/linear_regression_cv.py
@@ -1,0 +1,67 @@
+from typing import List
+from typing import NamedTuple
+
+import numpy
+from pydantic import BaseModel
+
+from mipengine.algorithms.linear_regression import LinearRegression
+from mipengine.algorithms.preprocessing import DummyEncoder
+from mipengine.algorithms.preprocessing import KFold
+from mipengine.algorithms.preprocessing import relation_to_vector
+
+
+class BasicStats(NamedTuple):
+    mean: float
+    std: float
+
+
+class CVLinearRegressionResult(BaseModel):
+    dependent_var: str
+    indep_vars: List[str]
+    n_obs: List[int]
+    mean_sq_error: BasicStats
+    r_squared: BasicStats
+    mean_abs_error: BasicStats
+
+
+def run(executor):
+    x_vars, y_vars = executor.x_variables, executor.y_variables
+    X, y = executor.create_primary_data_views(variable_groups=[x_vars, y_vars])
+    n_splits = executor.algorithm_parameters["n_splits"]
+
+    dummy_encoder = DummyEncoder(executor)
+    X = dummy_encoder.transform(X)
+
+    p = len(dummy_encoder.new_varnames) - 1
+
+    kf = KFold(executor, n_splits=n_splits)
+    X_train, X_test, y_train, y_test = kf.split(X, y)
+
+    models = [LinearRegression(executor) for _ in range(n_splits)]
+
+    for model, X, y in zip(models, X_train, y_train):
+        model.fit(X=X, y=y)
+
+    for model, X, y in zip(models, X_test, y_test):
+        y_pred = model.predict(X)
+        model.compute_summary(
+            y_test=relation_to_vector(y, executor),
+            y_pred=y_pred,
+            p=p,
+        )
+
+    rms_errors = numpy.array([m.rmse for m in models])
+    r2s = numpy.array([m.r_squared for m in models])
+    maes = numpy.array([m.mae for m in models])
+    f_stats = numpy.array([m.f_stat for m in models])
+
+    result = CVLinearRegressionResult(
+        dependent_var=executor.y_variables[0],
+        indep_vars=dummy_encoder.new_varnames,
+        n_obs=[m.n_obs for m in models],
+        mean_sq_error=BasicStats(mean=rms_errors.mean(), std=rms_errors.std(ddof=1)),
+        r_squared=BasicStats(mean=r2s.mean(), std=r2s.std(ddof=1)),
+        mean_abs_error=BasicStats(mean=maes.mean(), std=maes.std(ddof=1)),
+        f_stat=BasicStats(mean=f_stats.mean(), std=f_stats.std(ddof=1)),
+    )
+    return result

--- a/mipengine/algorithms/preprocessing.py
+++ b/mipengine/algorithms/preprocessing.py
@@ -56,7 +56,7 @@ class DummyEncoder:
     @staticmethod
     @udf(x=relation(), categorical_vars=literal(), return_type=transfer())
     def _gather_enums_local(x, categorical_vars):
-        categorical_vars = ["x_" + varname for varname in categorical_vars]
+        categorical_vars = [varname for varname in categorical_vars]
         enumerations = {}
         for cat in categorical_vars:
             enumerations[cat] = list(x[cat].unique())
@@ -79,7 +79,7 @@ class DummyEncoder:
             )
 
         keys = local_transfers[0]["enumerations"].keys()
-        enumerations = {key[2:]: reduce_enums(key) for key in keys}
+        enumerations = {key: reduce_enums(key) for key in keys}
 
         return enumerations
 

--- a/mipengine/algorithms/requests/linear_regression_cv_request.py
+++ b/mipengine/algorithms/requests/linear_regression_cv_request.py
@@ -1,0 +1,89 @@
+import json
+
+import requests
+from devtools import debug
+
+from mipengine.controller.api.algorithm_request_dto import AlgorithmInputDataDTO
+from mipengine.controller.api.algorithm_request_dto import AlgorithmRequestDTO
+
+
+def do_post_request():
+    url = "http://127.0.0.1:5000/algorithms" + "/linear_regression_cv"
+
+    x = [
+        "rightmfcmedialfrontalcortex",
+        "rightsogsuperioroccipitalgyrus",
+        "ppmicategory",
+    ]
+    y = ["leftcerebellumwhitematter"]
+    data_model = "dementia:0.1"
+    datasets = [
+        "desd-synthdata5",
+        "edsd1",
+        "desd-synthdata2",
+        "desd-synthdata4",
+        "desd-synthdata6",
+        "ppmi4",
+        "edsd9",
+        "desd-synthdata0",
+        "edsd7",
+        "ppmi6",
+    ]
+    filters = {
+        "condition": "AND",
+        "rules": [
+            {
+                "id": "dataset",
+                "type": "string",
+                "value": datasets,
+                "operator": "in",
+            },
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": variable,
+                        "type": "string",
+                        "operator": "is_not_null",
+                        "value": None,
+                    }
+                    for variable in x + y
+                ],
+            },
+        ],
+        "valid": True,
+    }
+    parameters = {"n_splits": 17}
+
+    algorithm_input_data = AlgorithmInputDataDTO(
+        data_model=data_model,
+        datasets=datasets,
+        filters=filters,
+        x=x,
+        y=y,
+    )
+
+    algorithm_request = AlgorithmRequestDTO(
+        inputdata=algorithm_input_data,
+        parameters=parameters,
+    )
+
+    print(f"POSTing to {url}:")
+    debug(algorithm_request)
+
+    request_json = algorithm_request.json()
+
+    headers = {"Content-type": "application/json", "Accept": "text/plain"}
+    response = requests.post(url, data=request_json, headers=headers)
+
+    return response
+
+
+if __name__ == "__main__":
+    response = do_post_request()
+    print("\nResponse:")
+    print(f"{response.status_code=}")
+    try:
+        print(f"Result={json.dumps(json.loads(response.text), indent=4)}")
+    except json.decoder.JSONDecodeError:
+        print(f"Something went wrong:\n{response.text}")

--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -324,7 +324,7 @@ def _validate_parameter_inside_min_max(
     if parameter_spec.max is not None and parameter_value > parameter_spec.max:
         raise BadUserInput(
             f"Parameter '{parameter_spec.label}' values "
-            f"should be less than {parameter_spec.max} ."
+            f"should be at most equal to {parameter_spec.max} ."
         )
 
 

--- a/mipengine/udfgen/__init__.py
+++ b/mipengine/udfgen/__init__.py
@@ -1,3 +1,4 @@
+from .udfgenerator import DEFERRED
 from .udfgenerator import TensorBinaryOp
 from .udfgenerator import TensorUnaryOp
 from .udfgenerator import generate_udf_queries
@@ -30,4 +31,5 @@ __all__ = [
     "TensorUnaryOp",
     "TensorBinaryOp",
     "make_unique_func_name",
+    "DEFERRED",
 ]

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -351,6 +351,7 @@ ANDLN = " " + AND + LN
 SPC4 = " " * 4
 SCOLON = ";"
 ROWID = "row_id"
+NODEID = "node_id"
 
 
 def get_smpc_build_template(secure_transfer_type):
@@ -816,7 +817,7 @@ class MergeTensorType(TableType, ParametrizedType, InputType, OutputType):
 
     @property
     def schema(self):
-        nodeid_column = [("node_id", dt.STR)]
+        nodeid_column = [(NODEID, dt.STR)]
         dimcolumns = [(f"dim{i}", dt.INT) for i in range(self.ndims)]
         valcolumn = [("val", self.dtype)]
         return nodeid_column + dimcolumns + valcolumn  # type: ignore
@@ -2512,7 +2513,7 @@ def convert_table_arg_to_table_ast_node(table_arg, alias=None):
 
 
 def nodeid_column():
-    return Cast(name="$node_id", type_=dt.STR.to_sql(), alias="node_id")
+    return Cast(name="$node_id", type_=dt.STR.to_sql(), alias=NODEID)
 
 
 # ~~~~~~~~~~~~~~~~~ CREATE TABLE and INSERT query generator ~~~~~~~~~ #
@@ -2557,7 +2558,7 @@ def _create_table_udf_output(
     if isinstance(output_type, ScalarType) or not nodeid:
         output_schema = iotype_to_sql_schema(output_type)
     else:
-        output_schema = f'"node_id" {dt.STR.to_sql()},' + iotype_to_sql_schema(
+        output_schema = f'"{NODEID}" {dt.STR.to_sql()},' + iotype_to_sql_schema(
             output_type
         )
     create_table = CREATE_TABLE + " $" + table_name + f"({output_schema})" + SCOLON

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -390,9 +390,9 @@ def get_table_build_template(input_type: "TableType"):
         raise TypeError(
             f"Build template only for InputTypes. Type provided: {input_type}"
         )
-    COLUMNS_COMPREHENSION_TMPL = "{{n: _columns[n] for n in {colnames}}}"
+    COLUMNS_COMPREHENSION_TMPL = "{{name: _columns[name_w_prefix] for name, name_w_prefix in zip({colnames}, {colnames_w_prefix})}}"
     if isinstance(input_type, RelationType):
-        return f"{{varname}} = pd.DataFrame({COLUMNS_COMPREHENSION_TMPL})"
+        return f"{{varname}} = pd.DataFrame({COLUMNS_COMPREHENSION_TMPL}).set_index('{ROWID}')"
     if isinstance(input_type, TensorType):
         return f"{{varname}} = udfio.from_tensor_table({COLUMNS_COMPREHENSION_TMPL})"
     if isinstance(input_type, MergeTensorType):
@@ -480,7 +480,7 @@ def get_main_return_stmt_template(output_type: "OutputType", smpc_used: bool):
             f"Return statement template only for OutputTypes. Type provided: {output_type}"
         )
     if isinstance(output_type, RelationType):
-        return "return udfio.as_relational_table(numpy.array({return_name}))"
+        return "return {return_name}.reset_index()"
     if isinstance(output_type, TensorType):
         return "return udfio.as_tensor_table(numpy.array({return_name}))"
     if isinstance(output_type, ScalarType):
@@ -1222,10 +1222,12 @@ class TableBuild(ASTNode):
         self.template = template
 
     def compile(self) -> str:
-        colnames = self.arg.type.column_names(prefix=self.arg_name)
+        colnames = self.arg.type.column_names()
+        colnames_w_prefix = self.arg.type.column_names(prefix=self.arg_name)
         return self.template.format(
             varname=self.arg_name,
             colnames=colnames,
+            colnames_w_prefix=colnames_w_prefix,
             table_name=self.arg.table_name,
         )
 
@@ -2125,7 +2127,7 @@ def is_statetype_schema(schema):
 
 
 def convert_table_schema_to_relation_schema(table_schema):
-    return [(c.name, c.dtype) for c in table_schema if c.name != ROWID]
+    return [(c.name, c.dtype) for c in table_schema if c.name != NODEID]
 
 
 # <--
@@ -2442,11 +2444,9 @@ def map_unknown_to_known_typeparams(
 
 
 def get_udf_select_template(output_type: OutputType, table_args: Dict[str, TableArg]):
-    tensors = get_table_ast_nodes_from_table_args(
-        table_args,
-        arg_type=(TensorArg),
-    )
+    tensors = get_table_ast_nodes_from_table_args(table_args, arg_type=TensorArg)
     relations = get_table_ast_nodes_from_table_args(table_args, arg_type=RelationArg)
+    verify_rowid_in_relations(relations)
     tables = tensors or relations
     columns = [column for table in tables for column in table.columns.values()]
     where_clause = get_where_clause_for_tensors(tensors) if tensors else None
@@ -2470,6 +2470,14 @@ def get_table_ast_nodes_from_table_args(table_args, arg_type):
         Table(name=table.table_name, columns=table.column_names())
         for table in get_items_of_type(arg_type, table_args).values()
     ]
+
+
+def verify_rowid_in_relations(relations):
+    for relation in relations:
+        if ROWID not in relation.columns:
+            raise UDFBadCall(
+                f"Relations should always have a row_id column. Got: {relation}"
+            )
 
 
 def get_where_clause_for_tensors(tensors):

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -1314,7 +1314,9 @@ class LiteralAssignments(ASTNode):
         self.literals = literals
 
     def compile(self) -> str:
-        return LN.join(f"{name} = {arg.value}" for name, arg in self.literals.items())
+        return LN.join(
+            f"{name} = {repr(arg.value)}" for name, arg in self.literals.items()
+        )
 
 
 class LoggerAssignment(ASTNode):

--- a/mipengine/udfgen/udfio.py
+++ b/mipengine/udfgen/udfio.py
@@ -53,19 +53,6 @@ def from_tensor_table(table: dict):
     return np.array(array)
 
 
-def as_relational_table(array: np.ndarray):
-    """
-    TODO Output of relational tables needs to be refactored
-    What objects can we return? Do we need a name parameter?
-    https://team-1617704806227.atlassian.net/browse/MIP-536
-
-    """
-    # assert len(array.shape) in (1, 2)
-    # names = (f"{name}_{i}" for i in range(array.shape[1]))
-    # out = {n: c for n, c in zip(names, array)}
-    return array
-
-
 def reduce_tensor_pair(op, a: pd.DataFrame, b: pd.DataFrame):
     ndims = len(a.columns) - 1
     dimensions = [f"dim{_}" for _ in range(ndims)]

--- a/mipengine/udfgen/udfio.py
+++ b/mipengine/udfgen/udfio.py
@@ -42,13 +42,6 @@ def as_tensor_table(array: np.ndarray):
 
 
 def from_tensor_table(table: dict):
-    # XXX Hack, find better way
-    table = {
-        re.sub(r"\w+_(dim\d+)", r"\1", key)
-        if re.match(r"\w+_(dim\d+)", key)
-        else re.sub(r"\w+_(val)", r"\1", key): val
-        for key, val in table.items()
-    }
     ndims = len(table) - 1
     multi_index = [table[f"dim{i}"] for i in range(ndims)]
     shape = [max(idx) + 1 for idx in multi_index]

--- a/tests/algorithm_validation_tests/expected/linear_regression_cv_expected.json
+++ b/tests/algorithm_validation_tests/expected/linear_regression_cv_expected.json
@@ -1,0 +1,3221 @@
+{
+    "test_cases": [
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "righthippocampus",
+                        "rightsogsuperioroccipitalgyrus",
+                        "leftppplanumpolare",
+                        "leftsmgsupramarginalgyrus",
+                        "leftgregyrusrectus",
+                        "rightitginferiortemporalgyrus",
+                        "leftcalccalcarinecortex"
+                    ],
+                    "y": [
+                        "leftocpoccipitalpole"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi3",
+                        "desd-synthdata8",
+                        "edsd8",
+                        "ppmi6",
+                        "edsd5",
+                        "desd-synthdata9",
+                        "desd-synthdata5",
+                        "edsd7"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 4
+                },
+                "test_case_num": 0
+            },
+            "output": {
+                "dependent_var": "leftocpoccipitalpole",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.32694966692409255,
+                    0.04597620371127873
+                ],
+                "r_squared": [
+                    0.5788846351175629,
+                    0.06580230052744243
+                ],
+                "mean_abs_error": [
+                    0.2455589694366026,
+                    0.03192292823854553
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "opticchiasm",
+                        "leftsfgsuperiorfrontalgyrus",
+                        "leftppplanumpolare",
+                        "leftainsanteriorinsula",
+                        "leftamygdala",
+                        "leftorifgorbitalpartoftheinferiorfrontalgyrus",
+                        "leftcuncuneus",
+                        "neurodegenerativescategories",
+                        "rightfofrontaloperculum",
+                        "rightpcggposteriorcingulategyrus",
+                        "lefthippocampus"
+                    ],
+                    "y": [
+                        "rightsmgsupramarginalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi6",
+                        "edsd5",
+                        "ppmi4",
+                        "edsd7",
+                        "desd-synthdata3",
+                        "ppmi0",
+                        "edsd1",
+                        "desd-synthdata1",
+                        "ppmi1",
+                        "ppmi7",
+                        "desd-synthdata4",
+                        "desd-synthdata5",
+                        "desd-synthdata8",
+                        "ppmi9",
+                        "edsd9",
+                        "edsd3",
+                        "desd-synthdata2",
+                        "edsd0",
+                        "ppmi3",
+                        "edsd4",
+                        "edsd2",
+                        "ppmi5",
+                        "desd-synthdata7",
+                        "edsd8",
+                        "desd-synthdata0",
+                        "desd-synthdata9",
+                        "ppmi2",
+                        "ppmi8",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 1
+            },
+            "output": {
+                "dependent_var": "rightsmgsupramarginalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.6891951233765509,
+                    0.06865335121880971
+                ],
+                "r_squared": [
+                    0.5780102768405869,
+                    0.057993917896924374
+                ],
+                "mean_abs_error": [
+                    0.5264506855874912,
+                    0.022489842015253784
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightprgprecentralgyrus",
+                        "subjectageyears",
+                        "rightofugoccipitalfusiformgyrus",
+                        "leftcerebellumwhitematter"
+                    ],
+                    "y": [
+                        "rightocpoccipitalpole"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi2",
+                        "desd-synthdata0",
+                        "desd-synthdata1",
+                        "edsd4",
+                        "edsd7",
+                        "edsd3",
+                        "edsd1",
+                        "desd-synthdata9",
+                        "ppmi5",
+                        "ppmi3",
+                        "ppmi4"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 4
+                },
+                "test_case_num": 2
+            },
+            "output": {
+                "dependent_var": "rightocpoccipitalpole",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.3405850619274152,
+                    0.052859640364822116
+                ],
+                "r_squared": [
+                    0.45889348188066953,
+                    0.12844249625632456
+                ],
+                "mean_abs_error": [
+                    0.269075670747621,
+                    0.038596591496189284
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightmogmiddleoccipitalgyrus",
+                        "leftsfgsuperiorfrontalgyrus",
+                        "leftttgtransversetemporalgyrus",
+                        "rightmcggmiddlecingulategyrus",
+                        "rightofugoccipitalfusiformgyrus",
+                        "rightttgtransversetemporalgyrus",
+                        "leftfugfusiformgyrus",
+                        "rightitginferiortemporalgyrus",
+                        "rightioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "leftputamen"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi8",
+                        "ppmi5",
+                        "ppmi1",
+                        "edsd0",
+                        "desd-synthdata6",
+                        "ppmi3",
+                        "edsd4",
+                        "ppmi4",
+                        "ppmi9",
+                        "desd-synthdata3",
+                        "edsd2",
+                        "desd-synthdata5",
+                        "desd-synthdata1",
+                        "edsd3",
+                        "ppmi6",
+                        "ppmi0",
+                        "edsd7",
+                        "desd-synthdata0",
+                        "edsd9",
+                        "edsd8",
+                        "desd-synthdata8",
+                        "edsd6",
+                        "edsd1"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 3
+            },
+            "output": {
+                "dependent_var": "leftputamen",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.4635198546963368,
+                    0.057015916204436586
+                ],
+                "r_squared": [
+                    0.20385653451599844,
+                    0.3577060382143867
+                ],
+                "mean_abs_error": [
+                    0.3641695964511301,
+                    0.05464404866629473
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcaudate",
+                        "neurodegenerativescategories",
+                        "leftsmgsupramarginalgyrus",
+                        "parkinsonbroadcategory",
+                        "leftfugfusiformgyrus"
+                    ],
+                    "y": [
+                        "leftsogsuperioroccipitalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd9",
+                        "desd-synthdata6",
+                        "ppmi9",
+                        "edsd0",
+                        "ppmi3",
+                        "ppmi0",
+                        "edsd3",
+                        "desd-synthdata9",
+                        "ppmi5",
+                        "edsd5",
+                        "desd-synthdata4",
+                        "edsd1",
+                        "ppmi1",
+                        "desd-synthdata2",
+                        "desd-synthdata8",
+                        "desd-synthdata5",
+                        "desd-synthdata3",
+                        "ppmi4"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 4
+            },
+            "output": {
+                "dependent_var": "leftsogsuperioroccipitalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.35154337911344397,
+                    0.059499173554883746
+                ],
+                "r_squared": [
+                    0.35493100329733995,
+                    0.13200506906969015
+                ],
+                "mean_abs_error": [
+                    0.29290076806801013,
+                    0.05973998543214888
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "agegroup",
+                        "leftbasalforebrain",
+                        "rightsogsuperioroccipitalgyrus",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "leftmcggmiddlecingulategyrus"
+                    ],
+                    "y": [
+                        "rightpcggposteriorcingulategyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd3",
+                        "ppmi4",
+                        "ppmi2",
+                        "desd-synthdata2",
+                        "ppmi8",
+                        "ppmi6",
+                        "desd-synthdata8",
+                        "edsd6",
+                        "ppmi9",
+                        "desd-synthdata9",
+                        "ppmi7",
+                        "edsd9",
+                        "desd-synthdata7",
+                        "desd-synthdata1",
+                        "desd-synthdata0",
+                        "desd-synthdata5",
+                        "edsd2",
+                        "edsd7",
+                        "desd-synthdata3",
+                        "edsd0",
+                        "ppmi5",
+                        "edsd8",
+                        "edsd5",
+                        "desd-synthdata4",
+                        "ppmi3",
+                        "edsd4",
+                        "edsd1",
+                        "ppmi0",
+                        "ppmi1",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 3
+                },
+                "test_case_num": 5
+            },
+            "output": {
+                "dependent_var": "rightpcggposteriorcingulategyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.3005833161058813,
+                    0.02914410421634886
+                ],
+                "r_squared": [
+                    0.6152642371633424,
+                    0.04659504993595762
+                ],
+                "mean_abs_error": [
+                    0.2248353424247085,
+                    0.017336250616570955
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "leftpoparietaloperculum",
+                        "leftcerebellumwhitematter",
+                        "rightfofrontaloperculum",
+                        "leftamygdala"
+                    ],
+                    "y": [
+                        "leftptplanumtemporale"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata6",
+                        "ppmi9",
+                        "ppmi2",
+                        "edsd4",
+                        "desd-synthdata5",
+                        "edsd8",
+                        "desd-synthdata7",
+                        "edsd7",
+                        "edsd2",
+                        "desd-synthdata3",
+                        "ppmi4",
+                        "edsd1",
+                        "edsd9",
+                        "ppmi1",
+                        "ppmi8",
+                        "desd-synthdata0",
+                        "ppmi5",
+                        "ppmi7",
+                        "desd-synthdata9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 6
+            },
+            "output": {
+                "dependent_var": "leftptplanumtemporale",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.16615453647585582,
+                    0.022315192213773677
+                ],
+                "r_squared": [
+                    0.6541928562442489,
+                    0.12363443040480561
+                ],
+                "mean_abs_error": [
+                    0.12263679517524231,
+                    0.009060049971474969
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightmogmiddleoccipitalgyrus",
+                        "rightppplanumpolare",
+                        "rightfofrontaloperculum",
+                        "rightententorhinalarea",
+                        "leftmtgmiddletemporalgyrus",
+                        "rightventraldc",
+                        "lefttrifgtriangularpartoftheinferiorfrontalgyrus",
+                        "leftfofrontaloperculum",
+                        "rightioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "leftcerebellumexterior"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata0",
+                        "ppmi7",
+                        "desd-synthdata2",
+                        "desd-synthdata1",
+                        "edsd8",
+                        "ppmi2",
+                        "desd-synthdata9",
+                        "edsd1",
+                        "edsd5",
+                        "ppmi3",
+                        "ppmi1",
+                        "desd-synthdata7",
+                        "ppmi8",
+                        "desd-synthdata3",
+                        "desd-synthdata8",
+                        "edsd0",
+                        "desd-synthdata6",
+                        "ppmi5",
+                        "ppmi6",
+                        "desd-synthdata5",
+                        "edsd3",
+                        "desd-synthdata4"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 4
+                },
+                "test_case_num": 7
+            },
+            "output": {
+                "dependent_var": "leftcerebellumexterior",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    4.709176996899421,
+                    0.8788165605734112
+                ],
+                "r_squared": [
+                    0.42650551125778396,
+                    0.026248761304613434
+                ],
+                "mean_abs_error": [
+                    3.120318045920357,
+                    0.43286121229937696
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightstgsuperiortemporalgyrus",
+                        "rightmcggmiddlecingulategyrus",
+                        "rightthalamusproper",
+                        "subjectage",
+                        "rightententorhinalarea",
+                        "cerebellarvermallobulesvivii",
+                        "lefthippocampus"
+                    ],
+                    "y": [
+                        "_4thventricle"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi7",
+                        "edsd4",
+                        "edsd5",
+                        "desd-synthdata4",
+                        "edsd9",
+                        "edsd7",
+                        "desd-synthdata2",
+                        "ppmi1",
+                        "desd-synthdata6",
+                        "edsd2",
+                        "desd-synthdata5",
+                        "ppmi6",
+                        "ppmi3",
+                        "edsd8",
+                        "edsd6",
+                        "desd-synthdata0",
+                        "ppmi4",
+                        "edsd0",
+                        "ppmi2",
+                        "ppmi9",
+                        "desd-synthdata7",
+                        "ppmi8",
+                        "desd-synthdata3"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 8
+            },
+            "output": {
+                "dependent_var": "_4thventricle",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.5108536423509216,
+                    0.0920144274491102
+                ],
+                "r_squared": [
+                    0.01991786272221614,
+                    0.0826019559549967
+                ],
+                "mean_abs_error": [
+                    0.36949957079756013,
+                    0.03353359079385703
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftscasubcallosalarea",
+                        "rightcerebellumwhitematter",
+                        "leftsmcsupplementarymotorcortex",
+                        "leftfrpfrontalpole",
+                        "rightcuncuneus",
+                        "rightpcuprecuneus",
+                        "leftbasalforebrain",
+                        "leftfugfusiformgyrus"
+                    ],
+                    "y": [
+                        "rightcerebellumexterior"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata9",
+                        "ppmi7",
+                        "edsd2",
+                        "ppmi0",
+                        "edsd4",
+                        "desd-synthdata2",
+                        "ppmi5",
+                        "ppmi2",
+                        "desd-synthdata6",
+                        "desd-synthdata7",
+                        "ppmi9",
+                        "ppmi6",
+                        "ppmi3"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 2
+                },
+                "test_case_num": 9
+            },
+            "output": {
+                "dependent_var": "rightcerebellumexterior",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    3.9526945567299854,
+                    1.084653589588904
+                ],
+                "r_squared": [
+                    0.5028061523380447,
+                    0.008266966846531255
+                ],
+                "mean_abs_error": [
+                    2.7331418836029884,
+                    0.5031651046500886
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "rightgregyrusrectus",
+                        "leftopifgopercularpartoftheinferiorfrontalgyrus",
+                        "rightententorhinalarea",
+                        "leftventraldc"
+                    ],
+                    "y": [
+                        "leftsplsuperiorparietallobule"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd5",
+                        "ppmi1",
+                        "edsd9",
+                        "edsd0",
+                        "edsd3",
+                        "edsd7",
+                        "desd-synthdata1",
+                        "desd-synthdata5",
+                        "desd-synthdata3",
+                        "ppmi2",
+                        "ppmi3",
+                        "edsd2",
+                        "desd-synthdata7",
+                        "edsd8",
+                        "ppmi9",
+                        "desd-synthdata6",
+                        "ppmi6",
+                        "desd-synthdata8",
+                        "desd-synthdata0",
+                        "edsd6",
+                        "ppmi7",
+                        "ppmi8",
+                        "desd-synthdata4",
+                        "ppmi0",
+                        "ppmi4",
+                        "desd-synthdata9",
+                        "desd-synthdata2",
+                        "ppmi5"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 10
+            },
+            "output": {
+                "dependent_var": "leftsplsuperiorparietallobule",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    1.0671852149805183,
+                    0.14327917203490675
+                ],
+                "r_squared": [
+                    0.3745437746889291,
+                    0.0886258557223211
+                ],
+                "mean_abs_error": [
+                    0.7565178722603029,
+                    0.06276783529660397
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcerebralwhitematter",
+                        "leftsogsuperioroccipitalgyrus",
+                        "leftlateralventricle",
+                        "rightmsfgsuperiorfrontalgyrusmedialsegment",
+                        "lefttmptemporalpole",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "rightitginferiortemporalgyrus",
+                        "leftioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "rightcerebellumwhitematter"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata7",
+                        "edsd1",
+                        "ppmi4",
+                        "ppmi5",
+                        "edsd0",
+                        "desd-synthdata9",
+                        "ppmi2",
+                        "desd-synthdata4",
+                        "edsd2",
+                        "ppmi3",
+                        "ppmi0",
+                        "ppmi8",
+                        "edsd4",
+                        "desd-synthdata0",
+                        "desd-synthdata2",
+                        "edsd3",
+                        "desd-synthdata3",
+                        "edsd7",
+                        "edsd8",
+                        "ppmi1",
+                        "desd-synthdata1",
+                        "desd-synthdata5",
+                        "edsd9",
+                        "desd-synthdata8",
+                        "desd-synthdata6",
+                        "ppmi6",
+                        "edsd6",
+                        "ppmi9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 11
+            },
+            "output": {
+                "dependent_var": "rightcerebellumwhitematter",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    1.438274458216157,
+                    0.16277618570939553
+                ],
+                "r_squared": [
+                    0.5287486257776451,
+                    0.04448819647178806
+                ],
+                "mean_abs_error": [
+                    1.0495848660655855,
+                    0.0645643527854494
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftpoparietaloperculum",
+                        "righttrifgtriangularpartoftheinferiorfrontalgyrus",
+                        "leftorifgorbitalpartoftheinferiorfrontalgyrus",
+                        "rightofugoccipitalfusiformgyrus",
+                        "_3rdventricle",
+                        "righttmptemporalpole"
+                    ],
+                    "y": [
+                        "leftventraldc"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd6",
+                        "edsd1",
+                        "ppmi4",
+                        "edsd7",
+                        "ppmi2",
+                        "desd-synthdata8",
+                        "edsd4",
+                        "ppmi9",
+                        "desd-synthdata2",
+                        "desd-synthdata6",
+                        "edsd2",
+                        "desd-synthdata1",
+                        "edsd8",
+                        "edsd5",
+                        "ppmi8"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 12
+            },
+            "output": {
+                "dependent_var": "leftventraldc",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.3685829250670271,
+                    0.02293194745410213
+                ],
+                "r_squared": [
+                    0.3668882682255495,
+                    0.03846345691458509
+                ],
+                "mean_abs_error": [
+                    0.27723550724779805,
+                    0.005555398106372408
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "cerebellarvermallobulesvivii",
+                        "leftstgsuperiortemporalgyrus",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "leftpogpostcentralgyrus"
+                    ],
+                    "y": [
+                        "leftbasalforebrain"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi2",
+                        "edsd6",
+                        "ppmi9",
+                        "desd-synthdata9",
+                        "edsd2",
+                        "edsd4",
+                        "edsd5",
+                        "ppmi8",
+                        "ppmi6",
+                        "desd-synthdata4",
+                        "ppmi7",
+                        "ppmi4",
+                        "desd-synthdata5",
+                        "desd-synthdata1",
+                        "desd-synthdata3",
+                        "edsd9",
+                        "ppmi0",
+                        "desd-synthdata7",
+                        "ppmi3",
+                        "edsd3",
+                        "desd-synthdata6",
+                        "desd-synthdata8",
+                        "edsd1",
+                        "desd-synthdata0",
+                        "edsd8",
+                        "edsd0",
+                        "desd-synthdata2",
+                        "ppmi1",
+                        "edsd7",
+                        "ppmi5"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 13
+            },
+            "output": {
+                "dependent_var": "leftbasalforebrain",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.02971925347062959,
+                    0.0037790291723710017
+                ],
+                "r_squared": [
+                    0.4874321994759,
+                    0.08467524846674233
+                ],
+                "mean_abs_error": [
+                    0.022420717064952408,
+                    0.0021145615295851817
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcerebellumwhitematter",
+                        "rightmpogpostcentralgyrusmedialsegment",
+                        "rightententorhinalarea",
+                        "_3rdventricle",
+                        "rightmsfgsuperiorfrontalgyrusmedialsegment",
+                        "lefttmptemporalpole",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "rightioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "leftcerebellumexterior"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd5",
+                        "ppmi5",
+                        "ppmi3",
+                        "desd-synthdata0",
+                        "desd-synthdata1",
+                        "edsd7",
+                        "edsd6",
+                        "ppmi7",
+                        "ppmi2",
+                        "desd-synthdata5",
+                        "desd-synthdata4",
+                        "edsd2",
+                        "desd-synthdata9",
+                        "edsd3",
+                        "edsd9",
+                        "ppmi6",
+                        "edsd8",
+                        "desd-synthdata8",
+                        "ppmi4",
+                        "ppmi9",
+                        "edsd1",
+                        "desd-synthdata2",
+                        "edsd0",
+                        "ppmi0",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 14
+            },
+            "output": {
+                "dependent_var": "leftcerebellumexterior",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    4.059150211524512,
+                    0.7108950071111361
+                ],
+                "r_squared": [
+                    0.5613051252852191,
+                    0.04230946181106173
+                ],
+                "mean_abs_error": [
+                    2.777474769884615,
+                    0.40306702696809127
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "_3rdventricle",
+                        "rightangangulargyrus",
+                        "rightainsanteriorinsula"
+                    ],
+                    "y": [
+                        "rightpcuprecuneus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata9",
+                        "edsd9",
+                        "desd-synthdata8",
+                        "ppmi8",
+                        "ppmi6",
+                        "desd-synthdata7",
+                        "ppmi5",
+                        "edsd6",
+                        "desd-synthdata2",
+                        "desd-synthdata1",
+                        "ppmi9",
+                        "ppmi3",
+                        "desd-synthdata6",
+                        "edsd7",
+                        "ppmi4",
+                        "desd-synthdata3",
+                        "ppmi1",
+                        "edsd1",
+                        "desd-synthdata5",
+                        "edsd4",
+                        "ppmi7",
+                        "desd-synthdata4",
+                        "ppmi0",
+                        "edsd5",
+                        "edsd2",
+                        "edsd3",
+                        "desd-synthdata0",
+                        "edsd8"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 15
+            },
+            "output": {
+                "dependent_var": "rightpcuprecuneus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.823634246710913,
+                    0.08941426170769122
+                ],
+                "r_squared": [
+                    0.5608965040817744,
+                    0.12756519777506437
+                ],
+                "mean_abs_error": [
+                    0.6315039576349188,
+                    0.05551191423073298
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "rightstgsuperiortemporalgyrus",
+                        "rightofugoccipitalfusiformgyrus",
+                        "rightcuncuneus",
+                        "leftocpoccipitalpole"
+                    ],
+                    "y": [
+                        "righttmptemporalpole"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd9",
+                        "desd-synthdata2",
+                        "ppmi9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 3
+                },
+                "test_case_num": 16
+            },
+            "output": {
+                "dependent_var": "righttmptemporalpole",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.5966892285624003,
+                    0.12758688555859055
+                ],
+                "r_squared": [
+                    0.5013350771527337,
+                    0.15427416408564337
+                ],
+                "mean_abs_error": [
+                    0.46228478434024384,
+                    0.09510611444098141
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftofugoccipitalfusiformgyrus",
+                        "rightmsfgsuperiorfrontalgyrusmedialsegment",
+                        "rightsmcsupplementarymotorcortex",
+                        "leftopifgopercularpartoftheinferiorfrontalgyrus",
+                        "leftmorgmedialorbitalgyrus",
+                        "rightventraldc",
+                        "rightioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "rightinflatvent"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi1",
+                        "desd-synthdata5",
+                        "ppmi7",
+                        "edsd8",
+                        "ppmi6",
+                        "edsd2",
+                        "edsd3",
+                        "edsd5",
+                        "desd-synthdata2",
+                        "desd-synthdata0",
+                        "ppmi5",
+                        "edsd0",
+                        "edsd7",
+                        "edsd4",
+                        "edsd1",
+                        "desd-synthdata9",
+                        "ppmi0",
+                        "edsd9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 3
+                },
+                "test_case_num": 17
+            },
+            "output": {
+                "dependent_var": "rightinflatvent",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.4279437404104371,
+                    0.06642428365277811
+                ],
+                "r_squared": [
+                    -0.021788497948527847,
+                    0.11146775178132363
+                ],
+                "mean_abs_error": [
+                    0.30456433390922627,
+                    0.02512930103012704
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcerebralwhitematter",
+                        "leftsogsuperioroccipitalgyrus",
+                        "leftputamen",
+                        "leftphgparahippocampalgyrus",
+                        "rightententorhinalarea",
+                        "leftliglingualgyrus",
+                        "leftmfcmedialfrontalcortex",
+                        "righttmptemporalpole",
+                        "rightttgtransversetemporalgyrus",
+                        "leftmtgmiddletemporalgyrus",
+                        "rightitginferiortemporalgyrus"
+                    ],
+                    "y": [
+                        "leftamygdala"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata5",
+                        "ppmi8",
+                        "ppmi4",
+                        "edsd1",
+                        "ppmi1",
+                        "ppmi7"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 18
+            },
+            "output": {
+                "dependent_var": "leftamygdala",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.04639662658190454,
+                    0.01073121131306144
+                ],
+                "r_squared": [
+                    0.7669378296782655,
+                    0.041728652586696585
+                ],
+                "mean_abs_error": [
+                    0.03643996363127331,
+                    0.009167827869076672
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "rightthalamusproper",
+                        "rightcuncuneus",
+                        "rightpoparietaloperculum",
+                        "leftorifgorbitalpartoftheinferiorfrontalgyrus",
+                        "agegroup",
+                        "rightainsanteriorinsula",
+                        "rightprgprecentralgyrus",
+                        "rightcerebellumexterior",
+                        "rightfofrontaloperculum",
+                        "rightpcggposteriorcingulategyrus",
+                        "leftlorglateralorbitalgyrus"
+                    ],
+                    "y": [
+                        "leftbasalforebrain"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd5",
+                        "desd-synthdata2",
+                        "desd-synthdata6",
+                        "edsd4",
+                        "desd-synthdata3",
+                        "ppmi4",
+                        "ppmi7",
+                        "ppmi9",
+                        "desd-synthdata7",
+                        "ppmi0",
+                        "edsd3",
+                        "edsd2",
+                        "ppmi2",
+                        "edsd0",
+                        "ppmi1",
+                        "desd-synthdata1",
+                        "desd-synthdata8",
+                        "desd-synthdata0",
+                        "desd-synthdata5",
+                        "edsd6",
+                        "edsd8",
+                        "ppmi3",
+                        "desd-synthdata4",
+                        "ppmi5",
+                        "ppmi8",
+                        "edsd1",
+                        "edsd9",
+                        "edsd7"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 7
+                },
+                "test_case_num": 19
+            },
+            "output": {
+                "dependent_var": "leftbasalforebrain",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.027459759078864502,
+                    0.004497323149560251
+                ],
+                "r_squared": [
+                    0.5789636941239371,
+                    0.09569893989886678
+                ],
+                "mean_abs_error": [
+                    0.020048257509401052,
+                    0.002138297951033922
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftprgprecentralgyrus",
+                        "leftttgtransversetemporalgyrus",
+                        "leftsplsuperiorparietallobule",
+                        "leftcerebellumwhitematter",
+                        "leftstgsuperiortemporalgyrus",
+                        "rightmprgprecentralgyrusmedialsegment",
+                        "leftocpoccipitalpole"
+                    ],
+                    "y": [
+                        "leftainsanteriorinsula"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi1",
+                        "desd-synthdata3",
+                        "ppmi2",
+                        "edsd6",
+                        "edsd3",
+                        "ppmi7",
+                        "desd-synthdata1",
+                        "edsd1",
+                        "desd-synthdata8",
+                        "ppmi3"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 9
+                },
+                "test_case_num": 20
+            },
+            "output": {
+                "dependent_var": "leftainsanteriorinsula",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.3414279984471321,
+                    0.07282536268327529
+                ],
+                "r_squared": [
+                    0.5730376835209972,
+                    0.06878386916086755
+                ],
+                "mean_abs_error": [
+                    0.25468476553679253,
+                    0.033644452834136876
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightsfgsuperiorfrontalgyrus"
+                    ],
+                    "y": [
+                        "rightententorhinalarea"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd3",
+                        "desd-synthdata7",
+                        "desd-synthdata2",
+                        "ppmi7",
+                        "edsd8"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 2
+                },
+                "test_case_num": 21
+            },
+            "output": {
+                "dependent_var": "rightententorhinalarea",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.22809987039266783,
+                    0.04234601051911104
+                ],
+                "r_squared": [
+                    0.10461559311953733,
+                    0.18469264065346103
+                ],
+                "mean_abs_error": [
+                    0.169212622026426,
+                    0.019404694845153066
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightsmgsupramarginalgyrus",
+                        "opticchiasm",
+                        "leftcerebellumexterior",
+                        "rightstgsuperiortemporalgyrus",
+                        "rightppplanumpolare",
+                        "rightlateralventricle",
+                        "leftioginferioroccipitalgyrus",
+                        "leftpogpostcentralgyrus",
+                        "rightgregyrusrectus",
+                        "rightventraldc",
+                        "rightprgprecentralgyrus",
+                        "rightaorganteriororbitalgyrus",
+                        "edsdcategory",
+                        "leftcuncuneus"
+                    ],
+                    "y": [
+                        "rightporgposteriororbitalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata9",
+                        "desd-synthdata6",
+                        "desd-synthdata5",
+                        "edsd8",
+                        "desd-synthdata3",
+                        "desd-synthdata8",
+                        "ppmi1",
+                        "desd-synthdata2",
+                        "edsd0",
+                        "edsd7",
+                        "ppmi9",
+                        "ppmi6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 22
+            },
+            "output": {
+                "dependent_var": "rightporgposteriororbitalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.1608253262992453,
+                    0.029309778134804954
+                ],
+                "r_squared": [
+                    0.6269710630720589,
+                    0.06456017696950843
+                ],
+                "mean_abs_error": [
+                    0.11831040692890732,
+                    0.012787260899272065
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftinflatvent",
+                        "rightmfgmiddlefrontalgyrus",
+                        "leftphgparahippocampalgyrus",
+                        "brainstem",
+                        "leftaorganteriororbitalgyrus",
+                        "rightmprgprecentralgyrusmedialsegment"
+                    ],
+                    "y": [
+                        "leftsfgsuperiorfrontalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi6",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 23
+            },
+            "output": {
+                "dependent_var": "leftsfgsuperiorfrontalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    1.0833751823720748,
+                    0.48280251570145244
+                ],
+                "r_squared": [
+                    0.42481672374196544,
+                    0.5570706219085074
+                ],
+                "mean_abs_error": [
+                    0.7743230707613922,
+                    0.15646024704253467
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightmogmiddleoccipitalgyrus",
+                        "leftstgsuperiortemporalgyrus",
+                        "rightpallidum",
+                        "leftamygdala",
+                        "leftmcggmiddlecingulategyrus",
+                        "righthippocampus",
+                        "leftbasalforebrain",
+                        "leftmfgmiddlefrontalgyrus",
+                        "leftpinsposteriorinsula",
+                        "rightmorgmedialorbitalgyrus"
+                    ],
+                    "y": [
+                        "rightptplanumtemporale"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi3",
+                        "ppmi4",
+                        "edsd2",
+                        "desd-synthdata2",
+                        "edsd5",
+                        "desd-synthdata9",
+                        "ppmi1",
+                        "desd-synthdata4",
+                        "edsd9",
+                        "ppmi2",
+                        "edsd7",
+                        "desd-synthdata7",
+                        "desd-synthdata1",
+                        "ppmi7"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 24
+            },
+            "output": {
+                "dependent_var": "rightptplanumtemporale",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.19088015637164638,
+                    0.031520587314068656
+                ],
+                "r_squared": [
+                    0.5007910499923434,
+                    0.11434380915615938
+                ],
+                "mean_abs_error": [
+                    0.1412322079839337,
+                    0.012619571182816973
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightttgtransversetemporalgyrus",
+                        "leftmfcmedialfrontalcortex"
+                    ],
+                    "y": [
+                        "leftitginferiortemporalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata8",
+                        "ppmi3",
+                        "edsd0",
+                        "desd-synthdata4",
+                        "desd-synthdata5",
+                        "edsd2",
+                        "ppmi5",
+                        "edsd4",
+                        "edsd8",
+                        "desd-synthdata3",
+                        "desd-synthdata1",
+                        "ppmi4",
+                        "desd-synthdata0",
+                        "edsd6",
+                        "ppmi6",
+                        "desd-synthdata9",
+                        "desd-synthdata7",
+                        "ppmi0"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 25
+            },
+            "output": {
+                "dependent_var": "leftitginferiortemporalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.9596649679870987,
+                    0.1389342347906894
+                ],
+                "r_squared": [
+                    0.47280620549280555,
+                    0.09376149741400858
+                ],
+                "mean_abs_error": [
+                    0.7501435373887547,
+                    0.09338966108999598
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightfugfusiformgyrus",
+                        "rightphgparahippocampalgyrus",
+                        "rightthalamusproper",
+                        "rightcalccalcarinecortex",
+                        "leftgregyrusrectus",
+                        "rightlorglateralorbitalgyrus"
+                    ],
+                    "y": [
+                        "leftphgparahippocampalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata9",
+                        "ppmi5",
+                        "edsd0",
+                        "ppmi7",
+                        "desd-synthdata2",
+                        "edsd1"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 2
+                },
+                "test_case_num": 26
+            },
+            "output": {
+                "dependent_var": "leftphgparahippocampalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.1319886071171598,
+                    0.019071761971396817
+                ],
+                "r_squared": [
+                    0.799698693592828,
+                    0.0519916624240657
+                ],
+                "mean_abs_error": [
+                    0.10038155743225222,
+                    0.01197516418247496
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightfugfusiformgyrus",
+                        "leftsfgsuperiorfrontalgyrus",
+                        "subjectage",
+                        "rightaorganteriororbitalgyrus",
+                        "leftitginferiortemporalgyrus"
+                    ],
+                    "y": [
+                        "leftporgposteriororbitalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata6",
+                        "ppmi9",
+                        "desd-synthdata0",
+                        "ppmi2",
+                        "desd-synthdata3"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 2
+                },
+                "test_case_num": 27
+            },
+            "output": {
+                "dependent_var": "leftporgposteriororbitalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.1756761288692175,
+                    0.024519962041593336
+                ],
+                "r_squared": [
+                    0.5379329892424721,
+                    0.06388355930641298
+                ],
+                "mean_abs_error": [
+                    0.1316817362750363,
+                    0.004649158283113408
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "rightpinsposteriorinsula",
+                        "rightinflatvent",
+                        "leftcocentraloperculum",
+                        "leftpcuprecuneus"
+                    ],
+                    "y": [
+                        "rightcuncuneus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd8",
+                        "desd-synthdata1",
+                        "desd-synthdata7",
+                        "edsd7",
+                        "desd-synthdata2",
+                        "desd-synthdata4",
+                        "edsd3",
+                        "edsd1",
+                        "desd-synthdata3",
+                        "desd-synthdata8",
+                        "edsd5",
+                        "desd-synthdata9",
+                        "desd-synthdata5",
+                        "ppmi3",
+                        "ppmi7",
+                        "edsd6",
+                        "ppmi8",
+                        "ppmi9",
+                        "desd-synthdata0",
+                        "desd-synthdata6",
+                        "ppmi1",
+                        "ppmi5",
+                        "ppmi2",
+                        "edsd9",
+                        "ppmi4",
+                        "edsd0"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 9
+                },
+                "test_case_num": 28
+            },
+            "output": {
+                "dependent_var": "rightcuncuneus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.48596782268763683,
+                    0.033258789444688644
+                ],
+                "r_squared": [
+                    0.37184953792161796,
+                    0.15450434898315102
+                ],
+                "mean_abs_error": [
+                    0.3737218692029944,
+                    0.027703440271296318
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftaccumbensarea",
+                        "righthippocampus"
+                    ],
+                    "y": [
+                        "rightmtgmiddletemporalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi5",
+                        "edsd1",
+                        "ppmi3",
+                        "desd-synthdata6",
+                        "desd-synthdata3",
+                        "edsd8",
+                        "ppmi7",
+                        "desd-synthdata2",
+                        "desd-synthdata7",
+                        "ppmi4",
+                        "edsd4",
+                        "desd-synthdata8",
+                        "ppmi1",
+                        "desd-synthdata1",
+                        "ppmi6",
+                        "edsd9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 3
+                },
+                "test_case_num": 29
+            },
+            "output": {
+                "dependent_var": "rightmtgmiddletemporalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    1.1439504793832764,
+                    0.009448430166188267
+                ],
+                "r_squared": [
+                    0.5529513510370444,
+                    0.07771321486950536
+                ],
+                "mean_abs_error": [
+                    0.8885829960336568,
+                    0.013507739320564174
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftaccumbensarea",
+                        "parkinsonbroadcategory",
+                        "leftpogpostcentralgyrus",
+                        "leftangangulargyrus",
+                        "rightphgparahippocampalgyrus",
+                        "leftmfgmiddlefrontalgyrus",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "rightmtgmiddletemporalgyrus"
+                    ],
+                    "y": [
+                        "rightscasubcallosalarea"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata7",
+                        "desd-synthdata5",
+                        "desd-synthdata4",
+                        "desd-synthdata2",
+                        "edsd0",
+                        "edsd6",
+                        "ppmi0",
+                        "desd-synthdata1",
+                        "ppmi1",
+                        "ppmi3",
+                        "desd-synthdata6",
+                        "ppmi4",
+                        "ppmi5",
+                        "edsd9",
+                        "ppmi8",
+                        "ppmi6",
+                        "desd-synthdata3",
+                        "edsd3",
+                        "edsd7",
+                        "desd-synthdata0",
+                        "ppmi2",
+                        "edsd1",
+                        "ppmi7",
+                        "edsd8",
+                        "edsd2",
+                        "ppmi9",
+                        "desd-synthdata9",
+                        "desd-synthdata8",
+                        "edsd4",
+                        "edsd5"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 30
+            },
+            "output": {
+                "dependent_var": "rightscasubcallosalarea",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.0875273740298554,
+                    0.00758155602460885
+                ],
+                "r_squared": [
+                    0.5823956339663289,
+                    0.08766441342088561
+                ],
+                "mean_abs_error": [
+                    0.06916966815228286,
+                    0.005132162255258945
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightsplsuperiorparietallobule",
+                        "rightsmgsupramarginalgyrus",
+                        "leftpallidum",
+                        "leftmfgmiddlefrontalgyrus",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "leftmsfgsuperiorfrontalgyrusmedialsegment",
+                        "leftcocentraloperculum"
+                    ],
+                    "y": [
+                        "rightmfcmedialfrontalcortex"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata3",
+                        "ppmi0"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 31
+            },
+            "output": {
+                "dependent_var": "rightmfcmedialfrontalcortex",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.13328742399813945,
+                    0.025742457903632967
+                ],
+                "r_squared": [
+                    0.7317060105664344,
+                    0.1260460632957266
+                ],
+                "mean_abs_error": [
+                    0.10083348362093687,
+                    0.014099836094992912
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftaccumbensarea",
+                        "rightmsfgsuperiorfrontalgyrusmedialsegment",
+                        "righttrifgtriangularpartoftheinferiorfrontalgyrus",
+                        "rightgregyrusrectus",
+                        "rightsfgsuperiorfrontalgyrus",
+                        "cerebellarvermallobulesiv",
+                        "leftlorglateralorbitalgyrus",
+                        "leftpcuprecuneus"
+                    ],
+                    "y": [
+                        "_3rdventricle"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd9",
+                        "ppmi2",
+                        "desd-synthdata8",
+                        "edsd3",
+                        "desd-synthdata5",
+                        "edsd0",
+                        "ppmi0",
+                        "desd-synthdata6",
+                        "ppmi4",
+                        "ppmi6",
+                        "edsd7",
+                        "ppmi3",
+                        "edsd4",
+                        "ppmi1",
+                        "desd-synthdata1"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 32
+            },
+            "output": {
+                "dependent_var": "_3rdventricle",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.47752548779640863,
+                    0.014820827203914507
+                ],
+                "r_squared": [
+                    0.10528386348704516,
+                    0.11690289587585459
+                ],
+                "mean_abs_error": [
+                    0.38180949709219064,
+                    0.007950589127428426
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "gender",
+                        "rightpoparietaloperculum",
+                        "leftangangulargyrus",
+                        "righttrifgtriangularpartoftheinferiorfrontalgyrus",
+                        "rightporgposteriororbitalgyrus",
+                        "leftcerebellumwhitematter",
+                        "rightptplanumtemporale",
+                        "leftitginferiortemporalgyrus"
+                    ],
+                    "y": [
+                        "lefthippocampus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata3",
+                        "edsd8",
+                        "ppmi1",
+                        "ppmi3",
+                        "desd-synthdata0",
+                        "ppmi8",
+                        "edsd4",
+                        "desd-synthdata6",
+                        "desd-synthdata5",
+                        "edsd7",
+                        "desd-synthdata1",
+                        "ppmi4",
+                        "ppmi2",
+                        "ppmi5",
+                        "ppmi6",
+                        "edsd6",
+                        "edsd5",
+                        "edsd3",
+                        "edsd9",
+                        "edsd2",
+                        "ppmi7",
+                        "desd-synthdata8",
+                        "ppmi0",
+                        "desd-synthdata7",
+                        "desd-synthdata2",
+                        "edsd1",
+                        "desd-synthdata9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 7
+                },
+                "test_case_num": 33
+            },
+            "output": {
+                "dependent_var": "lefthippocampus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.23393302786251394,
+                    0.03209603370654172
+                ],
+                "r_squared": [
+                    0.5641709733884278,
+                    0.03932181567382365
+                ],
+                "mean_abs_error": [
+                    0.18099955565124626,
+                    0.021185526066713138
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftfofrontaloperculum",
+                        "rightmfgmiddlefrontalgyrus",
+                        "leftmogmiddleoccipitalgyrus",
+                        "leftfugfusiformgyrus",
+                        "rightinflatvent",
+                        "rightmorgmedialorbitalgyrus"
+                    ],
+                    "y": [
+                        "leftmfcmedialfrontalcortex"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi4",
+                        "ppmi7",
+                        "edsd4",
+                        "ppmi6",
+                        "ppmi5",
+                        "edsd2",
+                        "desd-synthdata4"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 34
+            },
+            "output": {
+                "dependent_var": "leftmfcmedialfrontalcortex",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.12203744837520003,
+                    0.023160329692756516
+                ],
+                "r_squared": [
+                    0.7464220416040783,
+                    0.08671638479191751
+                ],
+                "mean_abs_error": [
+                    0.09234567864019488,
+                    0.013613185991462688
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightphgparahippocampalgyrus",
+                        "rightitginferiortemporalgyrus",
+                        "rightthalamusproper",
+                        "leftofugoccipitalfusiformgyrus"
+                    ],
+                    "y": [
+                        "righttrifgtriangularpartoftheinferiorfrontalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi3",
+                        "ppmi7",
+                        "ppmi0",
+                        "ppmi9",
+                        "desd-synthdata6",
+                        "desd-synthdata5",
+                        "edsd7",
+                        "ppmi5",
+                        "desd-synthdata1",
+                        "ppmi6",
+                        "desd-synthdata8",
+                        "edsd9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 35
+            },
+            "output": {
+                "dependent_var": "righttrifgtriangularpartoftheinferiorfrontalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.38873715971455786,
+                    0.09064418814663566
+                ],
+                "r_squared": [
+                    0.42248496940082714,
+                    0.06578654758340047
+                ],
+                "mean_abs_error": [
+                    0.2750236541604467,
+                    0.03139244768726737
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftsfgsuperiorfrontalgyrus",
+                        "leftmorgmedialorbitalgyrus",
+                        "leftthalamusproper",
+                        "leftacgganteriorcingulategyrus",
+                        "_3rdventricle",
+                        "leftphgparahippocampalgyrus"
+                    ],
+                    "y": [
+                        "leftcocentraloperculum"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata8",
+                        "ppmi0",
+                        "edsd2",
+                        "desd-synthdata5",
+                        "ppmi5",
+                        "ppmi8",
+                        "edsd6",
+                        "desd-synthdata6",
+                        "ppmi4",
+                        "edsd8",
+                        "desd-synthdata2",
+                        "edsd0",
+                        "ppmi1",
+                        "edsd9",
+                        "desd-synthdata7",
+                        "ppmi7",
+                        "desd-synthdata0",
+                        "ppmi2",
+                        "ppmi6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 36
+            },
+            "output": {
+                "dependent_var": "leftcocentraloperculum",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.31325093716923325,
+                    0.03114577277925675
+                ],
+                "r_squared": [
+                    0.5856353655530278,
+                    0.06692477942972933
+                ],
+                "mean_abs_error": [
+                    0.2387459429987437,
+                    0.016749760296170913
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcerebralwhitematter",
+                        "leftaccumbensarea",
+                        "_4thventricle",
+                        "rightangangulargyrus",
+                        "rightofugoccipitalfusiformgyrus",
+                        "rightsmcsupplementarymotorcortex",
+                        "leftgregyrusrectus",
+                        "rightinflatvent",
+                        "rightmprgprecentralgyrusmedialsegment",
+                        "leftamygdala",
+                        "leftporgposteriororbitalgyrus",
+                        "rightsplsuperiorparietallobule",
+                        "rightaorganteriororbitalgyrus",
+                        "leftpcuprecuneus"
+                    ],
+                    "y": [
+                        "rightmfgmiddlefrontalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd3",
+                        "edsd9",
+                        "ppmi3",
+                        "ppmi4",
+                        "desd-synthdata2",
+                        "ppmi0",
+                        "desd-synthdata0",
+                        "ppmi5",
+                        "edsd1",
+                        "desd-synthdata4",
+                        "desd-synthdata3",
+                        "edsd2",
+                        "ppmi6",
+                        "edsd4",
+                        "edsd7",
+                        "ppmi7",
+                        "ppmi1",
+                        "ppmi9",
+                        "edsd5",
+                        "desd-synthdata8",
+                        "desd-synthdata5",
+                        "desd-synthdata7",
+                        "ppmi2",
+                        "ppmi8",
+                        "edsd8",
+                        "desd-synthdata9",
+                        "desd-synthdata6",
+                        "edsd6",
+                        "desd-synthdata1",
+                        "edsd0"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 37
+            },
+            "output": {
+                "dependent_var": "rightmfgmiddlefrontalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    1.1513017024627448,
+                    0.15063198791712756
+                ],
+                "r_squared": [
+                    0.8018606412215571,
+                    0.04309764238463289
+                ],
+                "mean_abs_error": [
+                    0.8915931701750001,
+                    0.11394317792857334
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "lefttmptemporalpole"
+                    ],
+                    "y": [
+                        "leftcerebralwhitematter"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata8",
+                        "ppmi6",
+                        "ppmi1",
+                        "desd-synthdata2",
+                        "edsd2",
+                        "edsd6",
+                        "edsd8",
+                        "edsd5",
+                        "ppmi5",
+                        "ppmi2",
+                        "desd-synthdata3",
+                        "ppmi0",
+                        "edsd9",
+                        "desd-synthdata0",
+                        "ppmi3",
+                        "ppmi9",
+                        "edsd7",
+                        "edsd0",
+                        "desd-synthdata4",
+                        "ppmi8",
+                        "desd-synthdata1",
+                        "edsd4",
+                        "ppmi7",
+                        "edsd1",
+                        "desd-synthdata9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 7
+                },
+                "test_case_num": 38
+            },
+            "output": {
+                "dependent_var": "leftcerebralwhitematter",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    25.42836478507539,
+                    2.478278183632366
+                ],
+                "r_squared": [
+                    0.30606660507430167,
+                    0.07872456710536122
+                ],
+                "mean_abs_error": [
+                    19.43702440550494,
+                    1.42901740118784
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "parkinsonbroadcategory",
+                        "leftputamen",
+                        "leftmfcmedialfrontalcortex",
+                        "rightaccumbensarea"
+                    ],
+                    "y": [
+                        "rightacgganteriorcingulategyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi0",
+                        "ppmi4",
+                        "ppmi3",
+                        "desd-synthdata8",
+                        "edsd5",
+                        "desd-synthdata0",
+                        "ppmi5",
+                        "desd-synthdata2",
+                        "edsd6",
+                        "desd-synthdata3",
+                        "edsd3",
+                        "ppmi9",
+                        "ppmi7",
+                        "desd-synthdata6",
+                        "edsd7"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 9
+                },
+                "test_case_num": 39
+            },
+            "output": {
+                "dependent_var": "rightacgganteriorcingulategyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.336591446635727,
+                    0.0461962487117291
+                ],
+                "r_squared": [
+                    0.5862197726302785,
+                    0.07219293531302672
+                ],
+                "mean_abs_error": [
+                    0.27280674574730934,
+                    0.03598648361822977
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "opticchiasm",
+                        "parkinsonbroadcategory",
+                        "leftgregyrusrectus",
+                        "brainstem",
+                        "cerebellarvermallobulesvivii",
+                        "leftstgsuperiortemporalgyrus",
+                        "leftangangulargyrus",
+                        "rightsplsuperiorparietallobule",
+                        "leftorifgorbitalpartoftheinferiorfrontalgyrus",
+                        "lefthippocampus"
+                    ],
+                    "y": [
+                        "leftliglingualgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata5",
+                        "desd-synthdata7",
+                        "edsd5",
+                        "desd-synthdata0",
+                        "ppmi0",
+                        "edsd8",
+                        "edsd4",
+                        "edsd6",
+                        "ppmi7",
+                        "edsd9",
+                        "edsd2",
+                        "ppmi2",
+                        "ppmi9",
+                        "ppmi6",
+                        "desd-synthdata8"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 7
+                },
+                "test_case_num": 40
+            },
+            "output": {
+                "dependent_var": "leftliglingualgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.4318084153844152,
+                    0.02008439802229465
+                ],
+                "r_squared": [
+                    0.6527846257808607,
+                    0.039299774594060054
+                ],
+                "mean_abs_error": [
+                    0.3428834003238352,
+                    0.02590617817596806
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightcerebralwhitematter",
+                        "_4thventricle",
+                        "rightpogpostcentralgyrus",
+                        "rightstgsuperiortemporalgyrus",
+                        "leftputamen",
+                        "rightpinsposteriorinsula",
+                        "leftphgparahippocampalgyrus",
+                        "leftainsanteriorinsula",
+                        "righthippocampus",
+                        "leftmtgmiddletemporalgyrus",
+                        "leftbasalforebrain",
+                        "leftcerebellumwhitematter",
+                        "rightaorganteriororbitalgyrus",
+                        "leftfofrontaloperculum"
+                    ],
+                    "y": [
+                        "rightbasalforebrain"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata7",
+                        "ppmi8",
+                        "edsd2",
+                        "desd-synthdata8",
+                        "ppmi4",
+                        "edsd6",
+                        "desd-synthdata3",
+                        "desd-synthdata4",
+                        "ppmi0",
+                        "ppmi9",
+                        "edsd0",
+                        "ppmi3",
+                        "edsd4",
+                        "edsd8",
+                        "edsd1",
+                        "edsd7",
+                        "desd-synthdata6",
+                        "desd-synthdata5",
+                        "edsd9",
+                        "ppmi6",
+                        "desd-synthdata0",
+                        "ppmi7",
+                        "desd-synthdata1",
+                        "edsd5",
+                        "ppmi1",
+                        "desd-synthdata2",
+                        "ppmi5",
+                        "ppmi2"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 6
+                },
+                "test_case_num": 41
+            },
+            "output": {
+                "dependent_var": "rightbasalforebrain",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.018776446980592425,
+                    0.004631268981622467
+                ],
+                "r_squared": [
+                    0.799935633161788,
+                    0.06304774344605744
+                ],
+                "mean_abs_error": [
+                    0.012751534781177866,
+                    0.0019431132647101893
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightangangulargyrus",
+                        "alzheimerbroadcategory",
+                        "rightmorgmedialorbitalgyrus"
+                    ],
+                    "y": [
+                        "rightlorglateralorbitalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata3",
+                        "ppmi2",
+                        "desd-synthdata8",
+                        "edsd2",
+                        "desd-synthdata6",
+                        "edsd4",
+                        "ppmi6",
+                        "desd-synthdata1",
+                        "edsd7",
+                        "desd-synthdata5",
+                        "desd-synthdata0",
+                        "edsd8",
+                        "ppmi9",
+                        "edsd6",
+                        "desd-synthdata9",
+                        "edsd3",
+                        "ppmi7",
+                        "edsd9",
+                        "desd-synthdata7",
+                        "desd-synthdata4",
+                        "ppmi5",
+                        "edsd0",
+                        "ppmi0",
+                        "edsd5",
+                        "ppmi3",
+                        "edsd1"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 42
+            },
+            "output": {
+                "dependent_var": "rightlorglateralorbitalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.1374162354869389,
+                    0.030793942105188498
+                ],
+                "r_squared": [
+                    0.756979282718691,
+                    0.04700099796580092
+                ],
+                "mean_abs_error": [
+                    0.09951460652895763,
+                    0.011602533788483535
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftlateralventricle",
+                        "gender",
+                        "rightmprgprecentralgyrusmedialsegment",
+                        "leftpogpostcentralgyrus",
+                        "rightorifgorbitalpartoftheinferiorfrontalgyrus",
+                        "righttrifgtriangularpartoftheinferiorfrontalgyrus",
+                        "leftpallidum",
+                        "leftopifgopercularpartoftheinferiorfrontalgyrus",
+                        "leftsplsuperiorparietallobule",
+                        "rightfofrontaloperculum"
+                    ],
+                    "y": [
+                        "rightpcuprecuneus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd9",
+                        "desd-synthdata4",
+                        "ppmi2",
+                        "desd-synthdata9",
+                        "desd-synthdata3",
+                        "desd-synthdata2",
+                        "edsd3",
+                        "edsd7",
+                        "edsd8",
+                        "ppmi8",
+                        "edsd0",
+                        "ppmi1",
+                        "edsd4",
+                        "desd-synthdata5",
+                        "ppmi4",
+                        "ppmi9",
+                        "edsd6",
+                        "desd-synthdata1",
+                        "edsd1",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 43
+            },
+            "output": {
+                "dependent_var": "rightpcuprecuneus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.7562933666018661,
+                    0.10217535206141562
+                ],
+                "r_squared": [
+                    0.603037750770105,
+                    0.10756738717854435
+                ],
+                "mean_abs_error": [
+                    0.577445216621491,
+                    0.07107861956481909
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightmogmiddleoccipitalgyrus",
+                        "rightfugfusiformgyrus",
+                        "leftputamen",
+                        "rightacgganteriorcingulategyrus",
+                        "rightcuncuneus",
+                        "rightscasubcallosalarea",
+                        "rightphgparahippocampalgyrus",
+                        "leftfugfusiformgyrus",
+                        "leftfofrontaloperculum",
+                        "leftmcggmiddlecingulategyrus",
+                        "rightioginferioroccipitalgyrus"
+                    ],
+                    "y": [
+                        "leftmorgmedialorbitalgyrus"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi8",
+                        "desd-synthdata8",
+                        "edsd7",
+                        "ppmi0",
+                        "edsd5",
+                        "edsd9",
+                        "ppmi2",
+                        "edsd6",
+                        "desd-synthdata0",
+                        "ppmi9",
+                        "ppmi4",
+                        "desd-synthdata5",
+                        "desd-synthdata6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 4
+                },
+                "test_case_num": 44
+            },
+            "output": {
+                "dependent_var": "leftmorgmedialorbitalgyrus",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.2559337078304401,
+                    0.026240203644400988
+                ],
+                "r_squared": [
+                    0.719793267445539,
+                    0.035461477699152436
+                ],
+                "mean_abs_error": [
+                    0.19980755331052613,
+                    0.01890086791034473
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightbasalforebrain",
+                        "csfglobal"
+                    ],
+                    "y": [
+                        "rightcocentraloperculum"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi3",
+                        "edsd3",
+                        "ppmi2",
+                        "edsd4",
+                        "desd-synthdata9",
+                        "edsd6",
+                        "edsd2",
+                        "edsd8",
+                        "desd-synthdata1",
+                        "desd-synthdata3",
+                        "desd-synthdata7",
+                        "ppmi5",
+                        "ppmi1",
+                        "ppmi0",
+                        "edsd9",
+                        "desd-synthdata0",
+                        "ppmi9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 10
+                },
+                "test_case_num": 45
+            },
+            "output": {
+                "dependent_var": "rightcocentraloperculum",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.4073782408177332,
+                    0.11847970647035316
+                ],
+                "r_squared": [
+                    0.40706443237138423,
+                    0.11386564540075872
+                ],
+                "mean_abs_error": [
+                    0.2811022159438603,
+                    0.046317666842968834
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftgregyrusrectus",
+                        "rightaorganteriororbitalgyrus"
+                    ],
+                    "y": [
+                        "rightmfcmedialfrontalcortex"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "edsd9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 9
+                },
+                "test_case_num": 46
+            },
+            "output": {
+                "dependent_var": "rightmfcmedialfrontalcortex",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.06343316112251733,
+                    0.02809094652704126
+                ],
+                "r_squared": [
+                    -115.86923198566234,
+                    233.42236926551058
+                ],
+                "mean_abs_error": [
+                    0.059336767662155294,
+                    0.027120652791891662
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "rightputamen",
+                        "rightmcggmiddlecingulategyrus",
+                        "leftphgparahippocampalgyrus",
+                        "subjectageyears",
+                        "righttmptemporalpole",
+                        "rightmfcmedialfrontalcortex",
+                        "leftcuncuneus",
+                        "edsdcategory",
+                        "leftententorhinalarea",
+                        "leftpcuprecuneus"
+                    ],
+                    "y": [
+                        "rightsmcsupplementarymotorcortex"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "ppmi7",
+                        "ppmi0",
+                        "ppmi6",
+                        "desd-synthdata7",
+                        "edsd9",
+                        "edsd5",
+                        "edsd2",
+                        "desd-synthdata3",
+                        "desd-synthdata6",
+                        "desd-synthdata0",
+                        "edsd3",
+                        "ppmi1",
+                        "ppmi2",
+                        "edsd4",
+                        "edsd8",
+                        "desd-synthdata1"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 8
+                },
+                "test_case_num": 47
+            },
+            "output": {
+                "dependent_var": "rightsmcsupplementarymotorcortex",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.3662549016651667,
+                    0.07150785320541965
+                ],
+                "r_squared": [
+                    0.6915995564706684,
+                    0.08274927822818019
+                ],
+                "mean_abs_error": [
+                    0.27909379605052925,
+                    0.04246453841142001
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftptplanumtemporale"
+                    ],
+                    "y": [
+                        "opticchiasm"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata9",
+                        "edsd3",
+                        "desd-synthdata8",
+                        "edsd5",
+                        "ppmi0",
+                        "edsd8",
+                        "desd-synthdata1",
+                        "edsd2",
+                        "ppmi2",
+                        "edsd0",
+                        "edsd6",
+                        "desd-synthdata6",
+                        "ppmi3",
+                        "desd-synthdata3",
+                        "ppmi8",
+                        "edsd4",
+                        "ppmi5",
+                        "ppmi1",
+                        "ppmi4",
+                        "desd-synthdata7",
+                        "ppmi7",
+                        "ppmi6"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 5
+                },
+                "test_case_num": 48
+            },
+            "output": {
+                "dependent_var": "opticchiasm",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.008975379575802741,
+                    0.000671926655567373
+                ],
+                "r_squared": [
+                    0.04599466284238858,
+                    0.06624439395492628
+                ],
+                "mean_abs_error": [
+                    0.00710747857929783,
+                    0.0004763649680257795
+                ]
+            }
+        },
+        {
+            "input": {
+                "inputdata": {
+                    "x": [
+                        "leftangangulargyrus",
+                        "rightporgposteriororbitalgyrus",
+                        "rightprgprecentralgyrus",
+                        "leftfofrontaloperculum",
+                        "rightpallidum"
+                    ],
+                    "y": [
+                        "leftptplanumtemporale"
+                    ],
+                    "data_model": "dementia:0.1",
+                    "datasets": [
+                        "desd-synthdata0",
+                        "desd-synthdata6",
+                        "ppmi0",
+                        "desd-synthdata5",
+                        "edsd6",
+                        "ppmi5",
+                        "edsd9",
+                        "edsd4",
+                        "ppmi6",
+                        "edsd8",
+                        "edsd3",
+                        "ppmi9",
+                        "edsd1",
+                        "edsd0",
+                        "ppmi1",
+                        "desd-synthdata8",
+                        "desd-synthdata7",
+                        "ppmi3",
+                        "edsd7",
+                        "desd-synthdata4",
+                        "desd-synthdata3",
+                        "edsd2",
+                        "edsd5",
+                        "ppmi8",
+                        "desd-synthdata1",
+                        "desd-synthdata9"
+                    ],
+                    "filters": ""
+                },
+                "parameters": {
+                    "n_splits": 3
+                },
+                "test_case_num": 49
+            },
+            "output": {
+                "dependent_var": "leftptplanumtemporale",
+                "indep_vars": [
+                    ""
+                ],
+                "n_obs": [
+                    0
+                ],
+                "mean_sq_error": [
+                    0.24761453177659776,
+                    0.00860338813448563
+                ],
+                "r_squared": [
+                    0.2859506762265404,
+                    0.10108252989288226
+                ],
+                "mean_abs_error": [
+                    0.19087695649333894,
+                    0.007542198839596913
+                ]
+            }
+        }
+    ]
+}

--- a/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
@@ -1,0 +1,109 @@
+"""
+Cross validation is non deterministic because it works by randomly splitting
+the datasets into train/test sets. This splitting is taken care of by sklearn
+in the state-of-the-art implementation and it's impossible to control or
+replicate in our federated implementation. For this reason the tests cannot be
+deterministic and we have to resort to statistical testing. In what follows,
+some quantity is computed for each CV fold. The way we test for equality
+between our and the SOA implementation is by conducting a two-tailed t-test
+with 99% confidence.
+"""
+import json
+from pathlib import Path
+
+import pytest
+import scipy.stats as st
+
+from tests.algorithm_validation_tests.helpers import algorithm_request
+from tests.algorithm_validation_tests.helpers import get_test_params
+
+expected_file = (
+    Path(__file__).parent / "expected" / "linear_regression_cv_expected.json"
+)
+
+
+@pytest.fixture(scope="module")
+def cache():
+    yield {}
+
+
+def get_cached_response(algorithm_name, test_input, cache):
+    test_case_num = test_input["test_case_num"]
+    if test_case_num in cache:
+        response = cache[test_case_num]
+    else:
+        response = algorithm_request(algorithm_name, test_input)
+        cache[test_case_num] = response
+    return response
+
+
+@pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
+def test_linearregression_cv_non_inferiority_msre(test_input, expected, cache):
+    response = get_cached_response("linear_regression_cv", test_input, cache)
+    try:
+        result = json.loads(response.text)
+    except json.decoder.JSONDecodeError:
+        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+
+    n_splits = test_input["parameters"]["n_splits"]
+    msre_res_mean, msre_res_std = result["mean_sq_error"]
+    msre_exp_mean, msre_exp_std = expected["mean_sq_error"]
+    ttest = st.ttest_ind_from_stats(
+        msre_res_mean,
+        msre_res_std,
+        n_splits,
+        msre_exp_mean,
+        msre_exp_std,
+        n_splits,
+        equal_var=True,
+        alternative="two-sided",
+    )
+    assert ttest.pvalue >= 0.01
+
+
+@pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
+def test_linearregression_cv_non_inferiority_mae(test_input, expected, cache):
+    response = get_cached_response("linear_regression_cv", test_input, cache)
+    try:
+        result = json.loads(response.text)
+    except json.decoder.JSONDecodeError:
+        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+
+    n_splits = test_input["parameters"]["n_splits"]
+    mae_res_mean, mae_res_std = result["mean_abs_error"]
+    mae_exp_mean, mae_exp_std = expected["mean_abs_error"]
+    ttest = st.ttest_ind_from_stats(
+        mae_res_mean,
+        mae_res_std,
+        n_splits,
+        mae_exp_mean,
+        mae_exp_std,
+        n_splits,
+        equal_var=True,
+        alternative="two-sided",
+    )
+    assert ttest.pvalue >= 0.01
+
+
+@pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
+def test_linearregression_cv_non_inferiority_r2(test_input, expected, cache):
+    response = get_cached_response("linear_regression_cv", test_input, cache)
+    try:
+        result = json.loads(response.text)
+    except json.decoder.JSONDecodeError:
+        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+
+    n_splits = test_input["parameters"]["n_splits"]
+    r2_res_mean, r2_res_std = result["r_squared"]
+    r2_exp_mean, r2_exp_std = expected["r_squared"]
+    ttest = st.ttest_ind_from_stats(
+        r2_res_mean,
+        r2_res_std,
+        n_splits,
+        r2_exp_mean,
+        r2_exp_std,
+        n_splits,
+        equal_var=True,
+        alternative="two-sided",
+    )
+    assert ttest.pvalue >= 0.01

--- a/tests/standalone_tests/test_udfgenerator.py
+++ b/tests/standalone_tests/test_udfgenerator.py
@@ -1253,7 +1253,7 @@ class TestUDFGen_InvalidUDFArgs_NamesMismatch(TestUDFGenBase):
         posargs = [TensorArg("table_name", dtype=int, ndims=1)]
         keywordargs = {"z": LiteralArg(1)}
         with pytest.raises(UDFBadCall) as exc:
-            _, _ = get_udf_templates_using_udfregistry(
+            get_udf_templates_using_udfregistry(
                 request_id=REQUEST_ID,
                 funcname=funcname,
                 posargs=posargs,
@@ -1280,7 +1280,7 @@ class TestUDFGen_LoggerArgument_provided_in_pos_args(TestUDFGenBase):
     def test_get_udf_templates(self, udfregistry, funcname):
         posargs = [TensorArg("table_name", dtype=int, ndims=1), LiteralArg(1)]
         with pytest.raises(UDFBadCall) as exc:
-            _, _ = get_udf_templates_using_udfregistry(
+            get_udf_templates_using_udfregistry(
                 request_id=REQUEST_ID,
                 funcname=funcname,
                 posargs=posargs,
@@ -1310,7 +1310,7 @@ class TestUDFGen_LoggerArgument_provided_in_kw_args(TestUDFGenBase):
         posargs = [TensorArg("table_name", dtype=int, ndims=1)]
         keywordargs = {"logger": LiteralArg(1)}
         with pytest.raises(UDFBadCall) as exc:
-            _, _ = get_udf_templates_using_udfregistry(
+            get_udf_templates_using_udfregistry(
                 request_id=REQUEST_ID,
                 funcname=funcname,
                 posargs=posargs,
@@ -1359,7 +1359,7 @@ class TestUDFGen_InvalidUDFArgs_TransferTableInStateArgument(TestUDFGenBase):
             ),
         ]
         with pytest.raises(UDFBadCall) as exc:
-            _, _ = generate_udf_queries(
+            generate_udf_queries(
                 request_id=REQUEST_ID,
                 func_name=funcname,
                 positional_args=posargs,
@@ -1455,7 +1455,7 @@ class TestUDFGen_Invalid_SMPCUDFInput_To_Transfer_Type(TestUDFGenBase):
             )
         ]
         with pytest.raises(UDFBadCall) as exc:
-            _ = generate_udf_queries(
+            generate_udf_queries(
                 request_id=REQUEST_ID,
                 func_name=funcname,
                 positional_args=posargs,
@@ -1490,19 +1490,9 @@ class TestUDFGen_Invalid_TableInfoArgs_To_SecureTransferType(TestUDFGenBase):
                 type_=TableType.NORMAL,
             ),
         ]
-        try:
-            _ = generate_udf_queries(
-                request_id=REQUEST_ID,
-                func_name=funcname,
-                positional_args=posargs,
-                keyword_args={},
-                smpc_used=False,
-            )
-        except Exception as exc:
-            pytest.fail(f"An exception should not have been raised. {exc}")
 
         with pytest.raises(UDFBadCall) as exc:
-            _ = generate_udf_queries(
+            generate_udf_queries(
                 request_id=REQUEST_ID,
                 func_name=funcname,
                 positional_args=posargs,
@@ -1549,7 +1539,7 @@ class TestUDFGen_Invalid_SMPCUDFInput_with_SMPC_off(TestUDFGenBase):
             )
         ]
         with pytest.raises(UDFBadCall) as exc:
-            _ = generate_udf_queries(
+            generate_udf_queries(
                 request_id=REQUEST_ID,
                 func_name=funcname,
                 positional_args=posargs,
@@ -1581,7 +1571,7 @@ class TestUDFGen_InvalidUDFArgs_InconsistentTypeVars(TestUDFGenBase):
         ]
         keywordargs = {}
         with pytest.raises(ValueError) as e:
-            _, _ = get_udf_templates_using_udfregistry(
+            get_udf_templates_using_udfregistry(
                 request_id=REQUEST_ID,
                 funcname=funcname,
                 posargs=posargs,
@@ -1599,7 +1589,7 @@ class TestUDFGen_KW_args_on_tensor_operation:
         posargs = []
         keywordargs = {"Μ": 5, "v": 7}
         with pytest.raises(UDFBadCall) as e:
-            _ = generate_udf_queries(
+            generate_udf_queries(
                 request_id=REQUEST_ID,
                 func_name=funcname,
                 positional_args=posargs,

--- a/tests/standalone_tests/test_udfio.py
+++ b/tests/standalone_tests/test_udfio.py
@@ -9,9 +9,9 @@ from mipengine.udfgen.udfio import split_secure_transfer_dict
 
 def test_merge_tensor_to_list_2tables_0D():
     columns = dict(
-        prefix_node_id=np.array(["a", "b"]),
-        prefix_dim0=np.array([0, 0]),
-        prefix_val=np.array([1, 2]),
+        node_id=np.array(["a", "b"]),
+        dim0=np.array([0, 0]),
+        val=np.array([1, 2]),
     )
     xs = merge_tensor_to_list(columns)
     assert xs == [np.array([1]), np.array([2])]
@@ -19,9 +19,9 @@ def test_merge_tensor_to_list_2tables_0D():
 
 def test_merge_tensor_to_list_2tables_1D():
     columns = dict(
-        prefix_node_id=np.array(["a", "a", "b", "b"]),
-        prefix_dim0=np.array([0, 1, 0, 1]),
-        prefix_val=np.array([1, 1, 2, 2]),
+        node_id=np.array(["a", "a", "b", "b"]),
+        dim0=np.array([0, 1, 0, 1]),
+        val=np.array([1, 1, 2, 2]),
     )
     expected_xs = [np.array([1, 1]), np.array([2, 2])]
     xs = merge_tensor_to_list(columns)
@@ -30,10 +30,10 @@ def test_merge_tensor_to_list_2tables_1D():
 
 def test_merge_tensor_to_list_2tables_2D():
     columns = dict(
-        prefix_node_id=np.array(["a", "a", "a", "a", "b", "b", "b", "b"]),
-        prefix_dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1]),
-        prefix_dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1]),
-        prefix_val=np.array([1, 1, 1, 1, 2, 2, 2, 2]),
+        node_id=np.array(["a", "a", "a", "a", "b", "b", "b", "b"]),
+        dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1]),
+        dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1]),
+        val=np.array([1, 1, 1, 1, 2, 2, 2, 2]),
     )
     expected_xs = [np.array([[1, 1], [1, 1]]), np.array([[2, 2], [2, 2]])]
     xs = merge_tensor_to_list(columns)
@@ -42,12 +42,10 @@ def test_merge_tensor_to_list_2tables_2D():
 
 def test_merge_tensor_to_list_3tables_2D():
     columns = dict(
-        prefix_node_id=np.array(
-            ["a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c"]
-        ),
-        prefix_dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]),
-        prefix_dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
-        prefix_val=np.array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]),
+        node_id=np.array(["a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c"]),
+        dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]),
+        dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
+        val=np.array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]),
     )
     expected_xs = [
         np.array([[1, 1], [1, 1]]),
@@ -60,15 +58,13 @@ def test_merge_tensor_to_list_3tables_2D():
 
 def test_merge_tensor_to_list_no_nodeid():
     columns = dict(
-        prefix_nodeid=np.array(
-            ["a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c"]
-        ),
-        prefix_dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]),
-        prefix_dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
-        prefix_val=np.array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]),
+        nodeid=np.array(["a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c"]),
+        dim0=np.array([0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]),
+        dim1=np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
+        val=np.array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]),
     )
     with pytest.raises(ValueError):
-        xs = merge_tensor_to_list(columns)
+        merge_tensor_to_list(columns)
 
 
 def get_secure_transfers_to_merged_dict_success_cases():

--- a/tests/testcase_generators/linear_regression_cv_testcase_generator.py
+++ b/tests/testcase_generators/linear_regression_cv_testcase_generator.py
@@ -1,0 +1,93 @@
+import numpy as np
+import pandas as pd
+import patsy
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
+from sklearn.base import BaseEstimator
+from sklearn.base import RegressorMixin
+from sklearn.model_selection import cross_val_score
+
+from mipengine.algorithms.linear_regression_cv import CVLinearRegressionResult
+from tests.testcase_generators.testcase_generator import TestCaseGenerator
+
+
+class StatsmodelsWrapper(BaseEstimator, RegressorMixin):
+    """Wrapper for statsmodels regression model with formula, exposing the same
+    methods as regression in sklearn. It is used as a wrapper for statsmodels
+    OLS in order to be able to use sklearn's `cross_val_score`."""
+
+    def __init__(self, model_class, formula):
+        self.model_class = model_class
+        self.formula = formula
+
+    def fit(self, X, y):
+        data = pd.concat([y, X], axis=1)
+        self.model_ = self.model_class(self.formula, data=data, missing="drop").fit()
+        return self
+
+    def predict(self, X):
+        X = sm.add_constant(X)
+        return self.model_.predict(X)
+
+
+class LinearRegressionTestCaseGenerator(TestCaseGenerator):
+    def compute_expected_output(self, input_data, params):
+        y, X = input_data
+        n_splits = params["n_splits"]
+
+        if n_splits >= len(y):
+            return  # Discard invalid test case
+
+        [yname] = y.columns
+        xnames = X.columns
+        formula = f"{yname}~{'+'.join(xnames)}"
+
+        model = StatsmodelsWrapper(smf.ols, formula)
+
+        try:
+            neg_rms_errors = cross_val_score(
+                model,
+                X,
+                y,
+                cv=n_splits,
+                scoring="neg_root_mean_squared_error",
+            )
+            rms_errors = np.array([-e for e in neg_rms_errors])
+            r2s = np.array(cross_val_score(model, X, y, cv=n_splits, scoring="r2"))
+            neg_maes = cross_val_score(
+                model, X, y, cv=n_splits, scoring="neg_mean_absolute_error"
+            )
+            maes = np.array([-e for e in neg_maes])
+        except patsy.PatsyError:
+            return  # Discard test case if patsy cannot parse formula
+
+        result = CVLinearRegressionResult(
+            dependent_var=yname,
+            indep_vars=[""],
+            n_obs=[0],
+            mean_sq_error=(rms_errors.mean(), rms_errors.std(ddof=1)),
+            r_squared=(r2s.mean(), r2s.std(ddof=1)),
+            mean_abs_error=(maes.mean(), maes.std(ddof=1)),
+        )
+
+        if result_has_nan(result):
+            return  # Some results have nans, not sure why but discard
+
+        return result.dict()
+
+
+def result_has_nan(result):
+    if np.isnan(result.mean_sq_error).any():
+        return True
+    if np.isnan(result.mean_abs_error).any():
+        return True
+    if np.isnan(result.r_squared).any():
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    with open("mipengine/algorithms/linear_regression_cv.json") as specs_file:
+        pcagen = LinearRegressionTestCaseGenerator(specs_file)
+    with open("linear_regression_cv_expected.json", "w") as expected_file:
+        pcagen.write_test_cases(expected_file, num_test_cases=50)

--- a/tests/testcase_generators/testcase_generator.py
+++ b/tests/testcase_generators/testcase_generator.py
@@ -346,6 +346,30 @@ class TestCaseGenerator(ABC):
 
     @abstractmethod
     def compute_expected_output(self, input_data, input_parameters=None):
+        """Computes the expected output for specific algorithm
+
+        This method has to be implemented by subclasses. The user should use
+        some state-of-the-art implementation (e.g. sklearn, statsmodels, ...)
+        of the algorithm in question to compute the expected results.
+
+        Parameters
+        ----------
+        input_data: tuple
+            A pair of design matrices. Either (y, x) or (y, None) depending on
+            the algorithm specs.
+        input_parameters: dict or None
+            A dict mapping algorithm parameters to values or None if the
+            algorithm doesn't have any parameters.
+
+        Returns
+        -------
+        dict or None
+            A dict containing the algorithm output. If no output can be
+            computed for the given input the implementer can return None, in
+            which case the test case is discarded. Use this for cases where the
+            test case generator generates seamingly valid inputs which do not
+            make sense for some reason.
+        """
         pass
 
     def get_input_data(self, input_):
@@ -382,20 +406,21 @@ class TestCaseGenerator(ABC):
             raise ValueError(
                 "Cannot find inputdata values resulting in non-empty data."
             )
-
         parameters = input_["parameters"]
-        try:
-            output = self.compute_expected_output(input_data, parameters)
-        except Exception as err:
-            raise Exception(f"{err}, datasets: {input_['inputdata']['datasets']}")
-
+        output = self.compute_expected_output(input_data, parameters)
         return {"input": input_, "output": output}
 
     def generate_test_cases(self, num_test_cases=100):
-        test_cases = [self.generate_test_case() for _ in tqdm(range(num_test_cases))]
+        test_cases = []
+        with tqdm(total=num_test_cases) as pbar:
+            while len(test_cases) < num_test_cases:
+                test_case = self.generate_test_case()
+                if test_case["output"]:
+                    test_cases.append(test_case)
+                    pbar.update(1)
 
         def append_test_case_number(test_case, num):
-            test_case["test_case_num"] = num
+            test_case["input"]["test_case_num"] = num
             return test_case
 
         test_cases = [


### PR DESCRIPTION
- Implementation of CV for Linear Regression. This is inefficient due to two reasons: 
  1. The implementation of KFold does a lot of calls to `run_udf_on_local_nodes` due to limitations in the current UDF generator.
  2. Cross-validation is completely parallelizable and should be done asynchronously but it is currently done synchronously. 
- UDF generator new feature: when a UDF takes a relational table as input, the `row_id` is passed as well and it is used as the index of the corresponding dataframe. 
- UDF generator new feature: a new constant `DEFERRED` can now be passed instead of an output relation's schema. This allows the user to defer the declaration of the schema to runtime. She is then required to pass the desired schema as an extra argument to `run_udf_on_local_nodes` or `run_udf_on_global_node`. The implementation is temporary and should be redesigned once the UDF generator is refactored.
- UDF generator enhancement: remove the variable name prefix in column names of relations/dataframes.
- Test case generator enhancement: when a generated input makes no sense it can be skipped by the implemented of `compute_expected_output` by simply returning `None`. 
- Various small fixes