### PR TITLE
MonetDB multi stage built.

### DIFF
--- a/.github/workflows/publish_dev_images.yml
+++ b/.github/workflows/publish_dev_images.yml
@@ -22,13 +22,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Load MONETDB cached image
-        uses: actions/cache@v2
+      - name: Build and Push MONETDB_base docker image to dockerhub
+        uses: docker/build-push-action@v2
         with:
-          path: /tmp/.buildx-cache/monetdb
-          key: ${{ runner.os }}-buildx-monetdb-${{hashFiles( 'monetdb/**' )}}
-          restore-keys: |
-            ${{ runner.os }}-buildx-monetdb-
+          context: .
+          file: monetdb/DockerfileBaseImage
+          push: true
+          tags: madgik/mipenginedb_base:latest
+
       - name: Build and Push MONETDB docker image to dockerhub
         uses: docker/build-push-action@v2
         with:
@@ -36,16 +37,7 @@ jobs:
           file: monetdb/Dockerfile
           push: true
           tags: madgik/mipenginedb:dev
-          cache-from: type=local,src=/tmp/.buildx-cache/monetdb
-          cache-to: type=local,dest=/tmp/.buildx-cache-new/monetdb
 
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Docker images cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   build_and_push_mipdb:
     name: Build MIPDB container image and push to dockerhub

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -21,19 +21,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Build and Push MONETDB_base docker image to dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: monetdb/DockerfileBaseImage
+          push: true
+          tags: madgik/mipenginedb_base:latest
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: madgik/mipenginedb
-
-      - name: Load MONETDB cached image
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache/monetdb
-          key: ${{ runner.os }}-buildx-monetdb-${{hashFiles( 'monetdb/**' )}}
-          restore-keys: |
-            ${{ runner.os }}-buildx-monetdb-
 
       - name: Build and Push MONETDB docker image to dockerhub
         uses: docker/build-push-action@v2
@@ -43,16 +43,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache/monetdb
-          cache-to: type=local,dest=/tmp/.buildx-cache-new/monetdb
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Docker images cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   build_and_push_mipdb:
     name: Build MIPDB container image and push to dockerhub

--- a/monetdb/Dockerfile
+++ b/monetdb/Dockerfile
@@ -1,45 +1,18 @@
-FROM ubuntu:20.04
-MAINTAINER Thanasis Karampatsis <tkarabatsis@athenarc.gr>
-LABEL version="1.4"
-
-ENV LANG=C.UTF-8
-
-#######################################################
-# Setting up timezone
-#######################################################
-ENV TZ=Etc/GMT
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt update && apt install -y wget
-
-#######################################################
-# Install monetdb requirements
-#######################################################
-RUN apt update && apt install -y software-properties-common
-RUN apt update && apt install -y cmake
-RUN apt update && apt install -y bison
-RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN apt update && apt install -y python3.8-dev
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
-
-RUN apt update && apt install -y libssl-dev libpcre3 libpcre3-dev pkg-config uuid-dev libxml2 libxml2-dev unixodbc-dev build-essential logrotate
-
-RUN apt update && apt install -y python3-pip
-RUN pip3 install numpy
+FROM madgik/mipenginedb_base
 
 #######################################################
 # Download monetdb source files
 #######################################################
-RUN wget --output-document=/home/MonetDB-11.43.9.tar.bz2 --no-check-certificate https://www.monetdb.org/downloads/sources/Jan2022-SP1/MonetDB-11.43.9.tar.bz2
-RUN tar -xf /home/MonetDB-11.43.9.tar.bz2 -C /home/
+RUN wget --output-document=/home/MonetDB-11.43.15.tar.bz2 --no-check-certificate https://www.monetdb.org/downloads/sources/Jan2022-SP3/MonetDB-11.43.15.tar.bz2
+RUN tar -xf /home/MonetDB-11.43.15.tar.bz2 -C /home/
 
 #######################################################
 # Install monetdb
 #######################################################
+RUN pip3 install numpy
 RUN mkdir /home/monetdb-build
 WORKDIR /home/monetdb-build
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DASSERT=ON -DSTRICT=ON -DCMAKE_INSTALL_PREFIX=/usr/local/bin/monetdb /home/MonetDB-11.43.9
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DASSERT=ON -DSTRICT=ON -DCMAKE_INSTALL_PREFIX=/usr/local/bin/monetdb /home/MonetDB-11.43.15
 RUN cmake --build .
 RUN cmake --build . --target install
 ENV PATH="/usr/local/bin/monetdb/bin:$PATH"
@@ -49,8 +22,8 @@ EXPOSE 50000
 #######################################################
 # Installation clean up
 #######################################################
-RUN rm /home/MonetDB-11.43.9.tar.bz2
-RUN rm -rf /home/MonetDB-11.43.9/
+RUN rm /home/MonetDB-11.43.15.tar.bz2
+RUN rm -rf /home/MonetDB-11.43.15/
 RUN rm -rf /home/monetdb-build
 
 #######################################################

--- a/monetdb/DockerfileBaseImage
+++ b/monetdb/DockerfileBaseImage
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+MAINTAINER Thanasis Karampatsis <tkarabatsis@athenarc.gr>
+
+ENV LANG=C.UTF-8
+
+#######################################################
+# Setting up timezone
+#######################################################
+ENV TZ=Etc/GMT
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+#######################################################
+# Install monetdb requirements
+#######################################################
+RUN apt update && apt install -y wget
+RUN apt update && apt install -y software-properties-common
+RUN apt update && apt install -y cmake
+RUN apt update && apt install -y bison
+RUN add-apt-repository -y ppa:deadsnakes/ppa
+RUN apt update && apt install -y python3.8-dev
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+
+RUN apt update && apt install -y libssl-dev libpcre3 libpcre3-dev pkg-config uuid-dev libxml2 libxml2-dev unixodbc-dev build-essential logrotate
+RUN apt update && apt install -y python3-pip

--- a/monetdb/README.md
+++ b/monetdb/README.md
@@ -1,4 +1,17 @@
-## Monetdb 11.39.13 (Oct2020-SP3) dockerized
+## Monetdb 11.43.15 (Jan2022-SP3) dockerized
+
+### Build the base image
+
+It is based on an `ubuntu:20.04` image and:
+
+- Sets up timezone
+- uses apt-update and apt-install to install all monetdb requirements
+
+To build a new image you must be on the project root `MIP-Engine/`, then
+
+```
+docker build -t madgik/mipenginedb_base:<IMAGETAG> -f monetdb/DockerfileBaseImage .
+```
 
 ### Build
 
@@ -15,7 +28,7 @@ docker build -t <USERNAME>/mipenginedb:<IMAGETAG> -f monetdb/Dockerfile .
 Then run with
 
 ```
-docker run -d -P -p 50000:50000 --name <CONTAINERNAME> <USERNAME>/mipenginedb:<IMAGETAG>
+docker run -d -p 50000:50000 --name <CONTAINERNAME> <USERNAME>/mipenginedb:<IMAGETAG>
 ```
 
 Access container db with


### PR DESCRIPTION
Changelog:
  - Updated MonetDB version to 11.43.15.
  - MonetDB docker image broken into 2 pieces. The base image contains all the `apt` commands that cannot be cached and the full image contains the rest, that can now be cached and speed up CI build time.