### PR TITLE
Marked all the tests with external dependencies as slow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,14 @@ repos:
     hooks:
     -   id: isort
         args: ["--profile", "black", "--force-single-line-imports"]
+
+-   repo: local
+    hooks:
+    -   id: pytest
+        name: pytest
+        stages: [commit]
+        language: system
+        entry: pytest tests/standalone_tests/ -m "not slow" -v
+        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,14 +25,3 @@ repos:
     hooks:
     -   id: isort
         args: ["--profile", "black", "--force-single-line-imports"]
-
--   repo: local
-    hooks:
-    -   id: pytest
-        name: pytest
-        stages: [commit]
-        language: system
-        entry: pytest tests/standalone_tests/ -m "not slow" -v
-        types: [python]
-        pass_filenames: false
-        always_run: true

--- a/tests/standalone_tests/test_algorithm_execution_tasks_handler.py
+++ b/tests/standalone_tests/test_algorithm_execution_tasks_handler.py
@@ -21,6 +21,7 @@ def test_table_params():
     return {"command_id": command_id, "schema": schema}
 
 
+@pytest.mark.slow
 def test_create_table(
     localnode1_tasks_handler, use_localnode1_database, test_table_params
 ):
@@ -42,6 +43,7 @@ def test_create_table(
     assert table_name_parts[3] == command_id
 
 
+@pytest.mark.slow
 def test_get_tables(
     localnode1_tasks_handler, use_localnode1_database, test_table_params
 ):
@@ -62,6 +64,7 @@ def test_get_tables(
     assert table_name in tables
 
 
+@pytest.mark.slow
 def test_get_table_schema(
     localnode1_tasks_handler, use_localnode1_database, test_table_params
 ):

--- a/tests/standalone_tests/test_celery_app.py
+++ b/tests/standalone_tests/test_celery_app.py
@@ -153,6 +153,7 @@ def test_celery_app_is_the_same_after_get_task_result_with_exception(
     ), "Celery app is different after the task threw an exception, even though the node never went down."
 
 
+@pytest.mark.slow
 def test_celery_app_is_different_after_queue_task_when_rabbitmq_is_down(
     reset_celery_app_factory,
     get_controller_testing_logger,
@@ -178,6 +179,7 @@ def test_celery_app_is_different_after_queue_task_when_rabbitmq_is_down(
     ), "The new celery app is not an instance of Celery. Something unexpected occurred during the reset."
 
 
+@pytest.mark.slow
 def test_celery_app_is_different_after_get_task_res_when_rabbitmq_is_down(
     reset_celery_app_factory,
     get_controller_testing_logger,

--- a/tests/standalone_tests/test_celery_app_factory.py
+++ b/tests/standalone_tests/test_celery_app_factory.py
@@ -56,6 +56,7 @@ def task_signatures():
 # TODO: create slow udf to provoke TimeoutException
 
 
+@pytest.mark.slow
 def test_queue_task(localnode1_node_service, task_signatures):
     socket_addr = f"{COMMON_IP}:{RABBITMQ_LOCALNODE1_PORT}"
     celery_app = CeleryWrapper(socket_addr=socket_addr)
@@ -77,6 +78,7 @@ def test_queue_task(localnode1_node_service, task_signatures):
     assert isinstance(async_result, celery.result.AsyncResult)
 
 
+@pytest.mark.slow
 def test_get_result(localnode1_node_service, task_signatures):
     socket_addr = f"{COMMON_IP}:{RABBITMQ_LOCALNODE1_PORT}"
     celery_app = CeleryWrapper(socket_addr=socket_addr)
@@ -105,6 +107,7 @@ def test_get_result(localnode1_node_service, task_signatures):
     assert isinstance(result, str)
 
 
+@pytest.mark.slow
 def test_queue_task_node_down(localnodetmp_node_service, task_signatures):
     socket_addr = f"{COMMON_IP}:{RABBITMQ_LOCALNODETMP_PORT}"
     celery_app = CeleryWrapper(socket_addr=socket_addr)
@@ -129,6 +132,7 @@ def test_queue_task_node_down(localnodetmp_node_service, task_signatures):
         )
 
 
+@pytest.mark.slow
 def test_get_result_node_down(localnodetmp_node_service, task_signatures):
     socket_addr = f"{COMMON_IP}:{RABBITMQ_LOCALNODETMP_PORT}"
     celery_app = CeleryWrapper(socket_addr=socket_addr)

--- a/tests/standalone_tests/test_federation_info_script.py
+++ b/tests/standalone_tests/test_federation_info_script.py
@@ -16,6 +16,7 @@ from tests.standalone_tests.conftest import MONETDB_LOCALNODETMP_PORT
 LOGFILE_NAME = "test_show_controller_audit_entries.out"
 
 
+@pytest.mark.slow
 def test_show_node_db_actions(monetdb_localnodetmp, load_data_localnodetmp):
     """
     Load data into the db and then remove datamodel and datasets.

--- a/tests/standalone_tests/test_get_data_model_cdes.py
+++ b/tests/standalone_tests/test_get_data_model_cdes.py
@@ -117,6 +117,7 @@ def get_test_cases_get_data_model_cdes():
     return test_cases_get_data_model_cdes
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "data_model, expected_data_model_cdes_length, expected_data_model_cdes",
     get_test_cases_get_data_model_cdes(),

--- a/tests/standalone_tests/test_get_datasets_per_data_model.py
+++ b/tests/standalone_tests/test_get_datasets_per_data_model.py
@@ -82,6 +82,7 @@ test_cases_get_node_info_datasets = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "expected_datasets_per_data_model",
     test_cases_get_node_info_datasets,

--- a/tests/standalone_tests/test_get_node_info.py
+++ b/tests/standalone_tests/test_get_node_info.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from mipengine.node_info_DTOs import NodeInfo
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
@@ -25,6 +27,7 @@ node_info_per_node = {
 }
 
 
+@pytest.mark.slow
 def test_get_node_info(
     localnode1_node_service,
     globalnode_node_service,

--- a/tests/standalone_tests/test_local_global_nodes_flow.py
+++ b/tests/standalone_tests/test_local_global_nodes_flow.py
@@ -35,6 +35,7 @@ def context_id(request_id):
     yield context_id
 
 
+@pytest.mark.slow
 def test_create_merge_table_with_remote_tables(
     request_id,
     context_id,

--- a/tests/standalone_tests/test_local_global_step_logic.py
+++ b/tests/standalone_tests/test_local_global_step_logic.py
@@ -32,6 +32,7 @@ def get_parametrization_list_success_cases():
     return [(algorithm_name, request_dict)]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "algorithm_name, request_dict",
     get_parametrization_list_success_cases(),

--- a/tests/standalone_tests/test_merge_tables.py
+++ b/tests/standalone_tests/test_merge_tables.py
@@ -93,6 +93,7 @@ def create_three_column_table_with_data(
     return table_name
 
 
+@pytest.mark.slow
 def test_create_and_get_merge_table(
     request_id,
     context_id,
@@ -133,6 +134,7 @@ def test_create_and_get_merge_table(
     assert merge_table_1_name in merge_tables
 
 
+@pytest.mark.slow
 def test_incompatible_schemas_merge(
     request_id,
     context_id,
@@ -165,6 +167,7 @@ def test_incompatible_schemas_merge(
         )
 
 
+@pytest.mark.slow
 def test_table_cannot_be_found(
     request_id,
     context_id,

--- a/tests/standalone_tests/test_pos_and_kw_args_in_algorithm_flow.py
+++ b/tests/standalone_tests/test_pos_and_kw_args_in_algorithm_flow.py
@@ -36,6 +36,7 @@ def get_parametrization_list_success_cases():
     return parametrization_list
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "algorithm_name, request_dict",
     get_parametrization_list_success_cases(),

--- a/tests/standalone_tests/test_remote_tables.py
+++ b/tests/standalone_tests/test_remote_tables.py
@@ -28,6 +28,7 @@ def context_id(request_id):
     yield context_id
 
 
+@pytest.mark.slow
 def test_create_and_get_remote_table(
     request_id,
     context_id,

--- a/tests/standalone_tests/test_single_local_node_algorithm_execution.py
+++ b/tests/standalone_tests/test_single_local_node_algorithm_execution.py
@@ -196,6 +196,7 @@ def get_parametrization_list_success_cases():
     return parametrization_list
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "algo_execution_dto",
     get_parametrization_list_success_cases(),

--- a/tests/standalone_tests/test_smpc_algorithms.py
+++ b/tests/standalone_tests/test_smpc_algorithms.py
@@ -330,6 +330,7 @@ def get_parametrization_list_success_cases():
     return parametrization_list
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 @pytest.mark.parametrize(
     "algorithm_name, request_dict, expected_response",
@@ -433,6 +434,7 @@ def get_parametrization_list_exception_cases():
     return parametrization_list
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 @pytest.mark.parametrize(
     "algorithm_name, request_dict, expected_response",

--- a/tests/standalone_tests/test_smpc_node_tasks.py
+++ b/tests/standalone_tests/test_smpc_node_tasks.py
@@ -198,6 +198,7 @@ def validate_table_data_match_expected(
     assert result == expected_values
 
 
+@pytest.mark.slow
 def test_secure_transfer_output_with_smpc_off(
     localnode1_node_service, use_localnode1_database, localnode1_celery_app
 ):
@@ -240,6 +241,7 @@ def test_secure_transfer_output_with_smpc_off(
     )
 
 
+@pytest.mark.slow
 def test_secure_transfer_input_with_smpc_off(
     localnode1_node_service, use_localnode1_database, localnode1_celery_app
 ):
@@ -284,6 +286,7 @@ def test_secure_transfer_input_with_smpc_off(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_validate_smpc_templates_match(
     smpc_localnode1_node_service,
@@ -308,6 +311,7 @@ def test_validate_smpc_templates_match(
         pytest.fail(f"No exception should be raised. Exception: {exc}")
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_validate_smpc_templates_dont_match(
     smpc_localnode1_node_service,
@@ -331,6 +335,7 @@ def test_validate_smpc_templates_dont_match(
     assert "SMPC templates dont match." in str(exc)
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_secure_transfer_run_udf_flow_with_smpc_on(
     smpc_localnode1_node_service,
@@ -427,6 +432,7 @@ def test_secure_transfer_run_udf_flow_with_smpc_on(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_load_data_to_smpc_client_from_globalnode_fails(
     smpc_globalnode_node_service,
@@ -446,6 +452,7 @@ def test_load_data_to_smpc_client_from_globalnode_fails(
     assert "load_data_to_smpc_client is allowed only for a LOCALNODE." in str(exc)
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_load_data_to_smpc_client(
     smpc_localnode1_node_service,
@@ -490,6 +497,7 @@ def test_load_data_to_smpc_client(
     assert json.dumps(result) == sum_op_values_str
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_get_smpc_result_from_localnode_fails(
     smpc_localnode1_node_service,
@@ -508,6 +516,7 @@ def test_get_smpc_result_from_localnode_fails(
     assert "get_smpc_result is allowed only for a GLOBALNODE." in str(exc)
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_get_smpc_result(
     smpc_globalnode_node_service,
@@ -582,6 +591,7 @@ def test_get_smpc_result(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.smpc
 def test_orchestrate_SMPC_between_two_localnodes_and_the_globalnode(
     smpc_globalnode_node_service,

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -32,6 +32,7 @@ def context_id(request_id):
     yield context_id
 
 
+@pytest.mark.slow
 def test_create_and_find_tables(
     request_id,
     context_id,

--- a/tests/standalone_tests/test_udfgenerator.py
+++ b/tests/standalone_tests/test_udfgenerator.py
@@ -1833,6 +1833,7 @@ FROM
             )
         ]
 
+    @pytest.mark.slow
     @pytest.mark.database
     @pytest.mark.usefixtures("use_globalnode_database", "create_tensor_table")
     def test_udf_with_db(

--- a/tests/standalone_tests/test_udfs.py
+++ b/tests/standalone_tests/test_udfs.py
@@ -64,6 +64,7 @@ def create_table_with_one_column_and_ten_rows(celery_app) -> Tuple[str, int]:
     return table_name, 55
 
 
+@pytest.mark.slow
 def test_get_udf(localnode1_node_service, localnode1_celery_app):
     get_udf_task = get_celery_task_signature("get_udf")
 
@@ -79,6 +80,7 @@ def test_get_udf(localnode1_node_service, localnode1_celery_app):
     assert get_column_rows.__name__ in fetched_udf
 
 
+@pytest.mark.slow
 def test_run_udf_relation_to_scalar(
     localnode1_node_service, use_localnode1_database, localnode1_celery_app
 ):
@@ -126,6 +128,7 @@ def test_run_udf_relation_to_scalar(
     assert table_data.columns[0].data[0] == 10
 
 
+@pytest.mark.slow
 def test_run_udf_state_and_transfer_output(
     localnode1_node_service,
     use_localnode1_database,

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -27,6 +27,7 @@ def context_id():
     return "testviews" + uuid.uuid4().hex
 
 
+@pytest.mark.slow
 def test_view_without_filters(
     request_id,
     context_id,
@@ -139,6 +140,7 @@ def test_view_without_filters(
     assert view_data.name == view_name
 
 
+@pytest.mark.slow
 def test_view_with_filters(
     request_id,
     context_id,
@@ -262,6 +264,7 @@ def test_view_with_filters(
     assert view_data.name == view_name
 
 
+@pytest.mark.slow
 def test_data_model_view_without_filters(
     request_id,
     context_id,
@@ -339,6 +342,7 @@ def test_data_model_view_without_filters(
     assert view_data.name == view_name
 
 
+@pytest.mark.slow
 def test_data_model_view_with_filters(
     request_id,
     context_id,
@@ -439,6 +443,7 @@ def test_data_model_view_with_filters(
     assert view_data.name == view_name
 
 
+@pytest.mark.slow
 def test_data_model_view_dataset_constraint(
     request_id,
     context_id,
@@ -482,6 +487,7 @@ def test_data_model_view_dataset_constraint(
     assert set(dataset_column.data) == {"dummy_tbi1"}
 
 
+@pytest.mark.slow
 def test_data_model_view_null_constraints(
     request_id,
     context_id,
@@ -556,6 +562,7 @@ def test_data_model_view_null_constraints(
     assert None in gose_score_column.data
 
 
+@pytest.mark.slow
 def test_data_model_view_min_rows_checks(
     request_id,
     context_id,
@@ -628,6 +635,7 @@ def test_data_model_view_min_rows_checks(
         )
 
 
+@pytest.mark.slow
 def test_data_model_view_with_data_model_unavailable_exception(
     request_id,
     context_id,
@@ -662,6 +670,7 @@ def test_data_model_view_with_data_model_unavailable_exception(
     )
 
 
+@pytest.mark.slow
 def test_data_model_view_with_dataset_unavailable_exception(
     request_id,
     context_id,
@@ -696,6 +705,7 @@ def test_data_model_view_with_dataset_unavailable_exception(
     )
 
 
+@pytest.mark.slow
 def test_multiple_data_model_views(
     request_id,
     context_id,
@@ -781,6 +791,7 @@ def test_multiple_data_model_views(
     assert schema2 == TableSchema.parse_raw(schema_result_json)
 
 
+@pytest.mark.slow
 def test_multiple_data_model_views_null_constraints(
     request_id,
     context_id,
@@ -851,6 +862,7 @@ def test_multiple_data_model_views_null_constraints(
     assert len(gcs_eye_response_scale_column.data) == 0
 
 
+@pytest.mark.slow
 def test_bad_filters_exception(controller_service):
     algorithm_name = "standard_deviation"
     request_params = {


### PR DESCRIPTION
Marked all the tests with external dependencies as slow.
Now pytest tests/standalone_tests/ -m "not slow" will run with:  **351 passed, 1 skipped, 77 deselected in 2.93s**