### PR TITLE
Dev/mip 650/node info tasks should have priority

### DIFF
--- a/.github/workflows/algorithm_validation_tests.yml
+++ b/.github/workflows/algorithm_validation_tests.yml
@@ -104,28 +104,28 @@ jobs:
           poetry run inv start-controller --detached
 
       - name: Controller logs
-        run: tail -n 1000 /tmp/mipengine/controller.out
+        run: cat /tmp/mipengine/controller.out
 
       - name: Globalnode logs
-        run: tail -n 1000 /tmp/mipengine/globalnode.out
+        run: cat /tmp/mipengine/globalnode.out
 
       - name: Localnode logs
-        run: tail -n 1000 /tmp/mipengine/localnode1.out
+        run: cat /tmp/mipengine/localnode1.out
 
       - name: Controller logs (post run)
         uses: webiny/action-post-run@2.0.1
         with:
-          run: tail -n 1000 /tmp/mipengine/controller.out
+          run: cat /tmp/mipengine/controller.out
 
       - name: Globalnode logs (post run)
         uses: webiny/action-post-run@2.0.1
         with:
-          run: tail -n 1000 /tmp/mipengine/globalnode.out
+          run: cat /tmp/mipengine/globalnode.out
 
       - name: Localnode logs (post run)
         uses: webiny/action-post-run@2.0.1
         with:
-          run: tail -n 1000 /tmp/mipengine/localnode1.out
+          run: cat /tmp/mipengine/localnode1.out
 
       - name: Run algorithm validation tests
         run: poetry run pytest tests/algorithm_validation_tests --verbosity=4 -n 16
@@ -249,4 +249,4 @@ jobs:
           run: cat /tmp/mipengine/localnode1.out
 
       - name: Run algorithm validation tests
-        run: poetry run pytest -vv tests/algorithm_validation_tests -k "input1 and not input1-" -n 16  # run tests 10-19
+        run: poetry run pytest tests/algorithm_validation_tests --verbosity=4 -n 16 -k "input1 and not input1-" # run tests 10-19

--- a/mipengine/celery_app_conf.py
+++ b/mipengine/celery_app_conf.py
@@ -1,0 +1,25 @@
+from kombu import Exchange
+from kombu import Queue
+
+CELERY_APP_QUEUE_MAX_PRIORITY = 10
+CELERY_APP_QUEUE_DEFAULT_PRIORITY = 5
+CELERY_APP_DEFAULT_QUEUE_NAME = "celery"
+
+
+def configure_celery_app_to_use_priority_queue(app):
+    # Disable prefetching
+    app.conf.worker_prefetch_multiplier = 1
+    # task_acks_late is also needed to disable prefetching
+    # https://stackoverflow.com/questions/16040039/understanding-celery-task-prefetching/33357180#33357180
+    app.conf.task_acks_late = True
+
+    app.conf.task_queue_max_priority = CELERY_APP_QUEUE_MAX_PRIORITY
+    app.conf.task_default_priority = CELERY_APP_QUEUE_DEFAULT_PRIORITY
+    app.conf.task_queues = [
+        Queue(
+            CELERY_APP_DEFAULT_QUEUE_NAME,
+            Exchange(CELERY_APP_DEFAULT_QUEUE_NAME),
+            routing_key=CELERY_APP_DEFAULT_QUEUE_NAME,
+            queue_arguments={"x-max-priority": CELERY_APP_QUEUE_MAX_PRIORITY},
+        ),
+    ]

--- a/mipengine/controller/node_info_tasks_handler.py
+++ b/mipengine/controller/node_info_tasks_handler.py
@@ -3,6 +3,7 @@ from typing import Final
 
 from celery.result import AsyncResult
 
+from mipengine.celery_app_conf import CELERY_APP_QUEUE_MAX_PRIORITY
 from mipengine.controller import controller_logger as ctrl_logger
 from mipengine.controller.celery_app import CeleryAppFactory
 from mipengine.controller.celery_app import CeleryWrapper
@@ -38,6 +39,7 @@ class NodeInfoTasksHandler:
             task_signature=task_signature,
             logger=logger,
             request_id=request_id,
+            priority=CELERY_APP_QUEUE_MAX_PRIORITY,
         )
         return async_result
 
@@ -64,6 +66,7 @@ class NodeInfoTasksHandler:
             task_signature=task_signature,
             logger=logger,
             request_id=request_id,
+            priority=CELERY_APP_QUEUE_MAX_PRIORITY,
         )
         return async_result
 
@@ -93,6 +96,7 @@ class NodeInfoTasksHandler:
             logger=logger,
             request_id=request_id,
             data_model=data_model,
+            priority=CELERY_APP_QUEUE_MAX_PRIORITY,
         )
         return async_result
 

--- a/mipengine/controller/node_landscape_aggregator.py
+++ b/mipengine/controller/node_landscape_aggregator.py
@@ -34,12 +34,16 @@ NODE_LANDSCAPE_AGGREGATOR_UPDATE_INTERVAL = (
     controller_config.node_landscape_aggregator_update_interval
 )
 CELERY_TASKS_TIMEOUT = controller_config.rabbitmq.celery_tasks_timeout
+NODE_INFO_TASKS_TIMEOUT = (
+    controller_config.rabbitmq.celery_tasks_timeout
+    + controller_config.rabbitmq.celery_run_udf_task_timeout
+)
 
 
 def _get_nodes_info(nodes_socket_addr: List[str]) -> List[NodeInfo]:
     node_info_tasks_handlers = [
         NodeInfoTasksHandler(
-            node_queue_addr=node_socket_addr, tasks_timeout=CELERY_TASKS_TIMEOUT
+            node_queue_addr=node_socket_addr, tasks_timeout=NODE_INFO_TASKS_TIMEOUT
         )
         for node_socket_addr in nodes_socket_addr
     ]
@@ -67,7 +71,7 @@ def _get_node_datasets_per_data_model(
     node_socket_addr: str,
 ) -> Dict[str, Dict[str, str]]:
     tasks_handler = NodeInfoTasksHandler(
-        node_queue_addr=node_socket_addr, tasks_timeout=CELERY_TASKS_TIMEOUT
+        node_queue_addr=node_socket_addr, tasks_timeout=NODE_INFO_TASKS_TIMEOUT
     )
     try:
         async_result = tasks_handler.queue_node_datasets_per_data_model_task(
@@ -92,7 +96,7 @@ def _get_node_datasets_per_data_model(
 
 def _get_node_cdes(node_socket_addr: str, data_model: str) -> CommonDataElements:
     tasks_handler = NodeInfoTasksHandler(
-        node_queue_addr=node_socket_addr, tasks_timeout=CELERY_TASKS_TIMEOUT
+        node_queue_addr=node_socket_addr, tasks_timeout=NODE_INFO_TASKS_TIMEOUT
     )
     try:
         async_result = tasks_handler.queue_data_model_cdes_task(

--- a/mipengine/controller/node_landscape_aggregator.py
+++ b/mipengine/controller/node_landscape_aggregator.py
@@ -34,10 +34,11 @@ NODE_LANDSCAPE_AGGREGATOR_UPDATE_INTERVAL = (
     controller_config.node_landscape_aggregator_update_interval
 )
 CELERY_TASKS_TIMEOUT = controller_config.rabbitmq.celery_tasks_timeout
-NODE_INFO_TASKS_TIMEOUT = (
-    controller_config.rabbitmq.celery_tasks_timeout
-    + controller_config.rabbitmq.celery_run_udf_task_timeout
-)
+CELERY_RUN_UDF_TASK_TIMEOUT = controller_config.rabbitmq.celery_run_udf_task_timeout
+
+# The timeout of the node info tasks should be the celery_tasks_timeout, incremented by the
+# celery_run_udf_task_timeout to avoid starvation due to udfs being executed.
+NODE_INFO_TASKS_TIMEOUT = CELERY_TASKS_TIMEOUT + CELERY_RUN_UDF_TASK_TIMEOUT
 
 
 def _get_nodes_info(nodes_socket_addr: List[str]) -> List[NodeInfo]:

--- a/mipengine/node/node.py
+++ b/mipengine/node/node.py
@@ -3,6 +3,7 @@ import logging
 from celery import Celery
 from celery import signals
 
+from mipengine.celery_app_conf import configure_celery_app_to_use_priority_queue
 from mipengine.node import config as node_config
 from mipengine.node.node_logger import init_logger
 
@@ -46,6 +47,9 @@ def setup_celery_logging(*args, **kwargs):
 
 
 celery.conf.worker_concurrency = node_config.celery.worker_concurrency
+
+configure_celery_app_to_use_priority_queue(celery)
+
 # TODO https://team-1617704806227.atlassian.net/browse/MIP-473
 # celery.conf.task_soft_time_limit = node_config.celery.task_soft_time_limit
 # celery.conf.task_time_limit = node_config.celery.task_time_limit

--- a/tests/algorithms/orphan_udfs.py
+++ b/tests/algorithms/orphan_udfs.py
@@ -45,7 +45,16 @@ def smpc_global_step(locals_result):
 
 
 @udf(table=relation(S), return_type=scalar(int))
-def slow_udf(table):
+def one_second_udf(table):
+    from time import sleep
+
+    sleep(1)
+    rows = [len(table)]
+    return rows
+
+
+@udf(table=relation(S), return_type=scalar(int))
+def five_seconds_udf(table):
     from time import sleep
 
     sleep(5)
@@ -54,9 +63,9 @@ def slow_udf(table):
 
 
 @udf(table=relation(S), return_type=scalar(int))
-def very_slow_udf(table):
+def one_hundred_seconds_udf(table):
     from time import sleep
 
-    sleep(1000)
+    sleep(100)
     rows = [len(table)]
     return rows

--- a/tests/standalone_tests/test_celery_app.py
+++ b/tests/standalone_tests/test_celery_app.py
@@ -14,7 +14,7 @@ from mipengine.node_tasks_DTOs import NodeTableDTO
 from mipengine.node_tasks_DTOs import UDFKeyArguments
 from mipengine.node_tasks_DTOs import UDFPosArguments
 from mipengine.udfgen import make_unique_func_name
-from tests.algorithms.orphan_udfs import slow_udf
+from tests.algorithms.orphan_udfs import five_seconds_udf
 from tests.standalone_tests.conftest import RABBITMQ_GLOBALNODE_ADDR
 from tests.standalone_tests.conftest import RABBITMQ_LOCALNODETMP_ADDR
 from tests.standalone_tests.conftest import RABBITMQ_LOCALNODETMP_NAME
@@ -66,9 +66,7 @@ def execute_task_and_assert_connection_error_raised(
 
 def queue_slow_udf(cel_app, logger):
     run_udf_task = get_celery_task_signature("run_udf")
-    input_table_name, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        cel_app
-    )
+    input_table_name, _ = create_table_with_one_column_and_ten_rows(cel_app, request_id)
     kw_args_str = UDFKeyArguments(
         args={"table": NodeTableDTO(value=input_table_name)}
     ).json()
@@ -79,7 +77,7 @@ def queue_slow_udf(cel_app, logger):
         request_id=request_id,
         command_id="1",
         context_id=request_id,
-        func_name=make_unique_func_name(slow_udf),
+        func_name=make_unique_func_name(five_seconds_udf),
         positional_args_json=UDFPosArguments(args=[]).json(),
         keyword_args_json=kw_args_str,
     )

--- a/tests/standalone_tests/test_node_info_tasks_priority.py
+++ b/tests/standalone_tests/test_node_info_tasks_priority.py
@@ -65,8 +65,10 @@ def test_node_info_tasks_have_higher_priority_over_other_tasks(
         for _ in range(number_of_udfs_to_schedule)
     ]
 
-    # The node info task should wait for one udf to complete, in order to start being executed,
+    # The node info task should wait for one udf to complete (~1-2sec), in order to start being executed,
     # but shouldn't wait for more than one, since it has priority of the other tasks.
+    # The timeout should be the time taken for one udf to complete, plus some additional time for
+    # the actual get_node_info task to complete.
     node_info_task_timeout = 3
     node_info_task_handler = NodeInfoTasksHandler(
         RABBITMQ_GLOBALNODE_ADDR, node_info_task_timeout

--- a/tests/standalone_tests/test_node_info_tasks_priority.py
+++ b/tests/standalone_tests/test_node_info_tasks_priority.py
@@ -1,0 +1,95 @@
+import pytest
+
+from mipengine.controller.celery_app import CeleryAppFactory
+from mipengine.controller.celery_app import CeleryTaskTimeoutException
+from mipengine.controller.node_info_tasks_handler import NodeInfoTasksHandler
+from mipengine.node import config as node_config
+from mipengine.node_info_DTOs import NodeInfo
+from mipengine.node_tasks_DTOs import NodeTableDTO
+from mipengine.node_tasks_DTOs import UDFKeyArguments
+from mipengine.node_tasks_DTOs import UDFPosArguments
+from mipengine.udfgen import make_unique_func_name
+from tests.algorithms.orphan_udfs import one_second_udf
+from tests.standalone_tests.conftest import RABBITMQ_GLOBALNODE_ADDR
+from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
+from tests.standalone_tests.test_udfs import create_table_with_one_column_and_ten_rows
+
+request_id = "TestingSystemCallPriority"
+command_id = 0
+
+
+def queue_one_second_udf(
+    cel_app,
+    input_table_name,
+    logger,
+):
+    run_udf_task = get_celery_task_signature("run_udf")
+
+    kw_args_str = UDFKeyArguments(
+        args={"table": NodeTableDTO(value=input_table_name)}
+    ).json()
+
+    global command_id
+    command_id += 1
+    return cel_app.queue_task(
+        task_signature=run_udf_task,
+        logger=logger,
+        request_id=request_id,
+        command_id=str(command_id),
+        context_id=request_id,
+        func_name=make_unique_func_name(one_second_udf),
+        positional_args_json=UDFPosArguments(args=[]).json(),
+        keyword_args_json=kw_args_str,
+    )
+
+
+@pytest.mark.slow
+def test_node_info_tasks_have_higher_priority_over_other_tasks(
+    globalnode_node_service,
+    reset_celery_app_factory,
+    get_controller_testing_logger,
+):
+    cel_app_wrapper = CeleryAppFactory().get_celery_app(RABBITMQ_GLOBALNODE_ADDR)
+
+    input_table_name, _ = create_table_with_one_column_and_ten_rows(
+        cel_app_wrapper, request_id
+    )
+
+    # Queue an X amount of udfs to fill the rabbitmq.
+    # The queued udfs should be greater than the NODE workers that consume them.
+    number_of_udfs_to_schedule = node_config.celery.worker_concurrency + 10
+    udf_async_results = [
+        queue_one_second_udf(
+            cel_app_wrapper, input_table_name, get_controller_testing_logger
+        )
+        for _ in range(number_of_udfs_to_schedule)
+    ]
+
+    # The node info task should wait for one udf to complete, in order to start being executed,
+    # but shouldn't wait for more than one, since it has priority of the other tasks.
+    node_info_task_timeout = 3
+    node_info_task_handler = NodeInfoTasksHandler(
+        RABBITMQ_GLOBALNODE_ADDR, node_info_task_timeout
+    )
+    node_info_ar = node_info_task_handler.queue_node_info_task(request_id)
+    try:
+        result = node_info_task_handler.result_node_info_task(node_info_ar, request_id)
+    except CeleryTaskTimeoutException as exc:
+        pytest.fail(
+            f"The node info task should not wait for the other tasks but a timeout occurred."
+            f"Exception: {exc}"
+        )
+    assert isinstance(result, NodeInfo)
+
+    for async_res in udf_async_results:
+        udf_tasks_timeout = number_of_udfs_to_schedule * 2
+        try:
+            cel_app_wrapper.get_result(
+                async_result=async_res,
+                timeout=udf_tasks_timeout,
+                logger=get_controller_testing_logger,
+            )
+        except Exception as exc:
+            pytest.fail(
+                f"An exception shouldn't occur. Exception Type: {type(exc)}, \n Exception: {exc}"
+            )

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_globalnode.toml
@@ -8,7 +8,7 @@ role = "GLOBALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode1.toml
@@ -8,7 +8,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode2.toml
@@ -8,7 +8,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_globalnode.toml
@@ -8,7 +8,7 @@ role = "GLOBALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnode1.toml
@@ -7,7 +7,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnode2.toml
@@ -7,7 +7,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_localnodetmp.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnodetmp.toml
@@ -8,7 +8,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_smpc_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_globalnode.toml
@@ -8,7 +8,7 @@ role = "GLOBALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_smpc_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_localnode1.toml
@@ -8,7 +8,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30

--- a/tests/standalone_tests/testing_env_configs/test_smpc_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_localnode2.toml
@@ -8,7 +8,7 @@ role = "LOCALNODE"
 minimum_row_count = 10
 
 [celery]
-worker_concurrency = 1
+worker_concurrency = 16
 task_soft_time_limit = 30
 task_time_limit = 60
 run_udf_soft_time_limit = 30


### PR DESCRIPTION
Changelog:
  - Minor bug fix for node config files having 'worker_concurrency' 1 instead of 16.
  - NodeInfoTasks now have higher priority over algorithm tasks. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-650)
  - Celery queue was changed into a priority queue.
