### PR TITLE
Dev/mip 636/serialize non select queries to avoid db corruption

### DIFF
--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -63,6 +63,10 @@ spec:
           value: {{ .Values.log_level }}
         - name: FRAMEWORK_LOG_LEVEL
           value: {{ .Values.framework_log_level }}
+        - name: CELERY_TASKS_TIMEOUT
+          value: {{ quote .Values.controller.celery_tasks_timeout }}
+        - name: CELERY_RUN_UDF_TASK_TIMEOUT
+          value: {{ quote .Values.controller.celery_run_udf_task_timeout }}
         - name: RABBITMQ_IP
           valueFrom:
             fieldRef:

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -91,6 +91,10 @@ spec:
           value: {{ .Values.log_level }}
         - name: FRAMEWORK_LOG_LEVEL
           value: {{ .Values.framework_log_level }}
+        - name: CELERY_TASKS_TIMEOUT
+          value: {{ quote .Values.controller.celery_tasks_timeout }}
+        - name: CELERY_RUN_UDF_TASK_TIMEOUT
+          value: {{ quote .Values.controller.celery_run_udf_task_timeout }}
         - name: RABBITMQ_IP
           valueFrom:
             fieldRef:

--- a/mipengine/node/config.toml
+++ b/mipengine/node/config.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout="$CELERY_TASKS_TIMEOUT"
+run_udf_task_timeout="$CELERY_RUN_UDF_TASK_TIMEOUT"
 
 [rabbitmq]
 ip = "$RABBITMQ_IP"

--- a/mipengine/node/monetdb_interface/common_actions.py
+++ b/mipengine/node/monetdb_interface/common_actions.py
@@ -1,9 +1,6 @@
-import itertools
-import logging
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Tuple
 
 from mipengine import DType
 from mipengine.exceptions import TablesNotFound

--- a/mipengine/node/monetdb_interface/monet_db_facade.py
+++ b/mipengine/node/monetdb_interface/monet_db_facade.py
@@ -56,6 +56,11 @@ class _MonetDBConnectionPool(metaclass=Singleton):
         )
 
     def get_connection(self):
+        """
+        We use pseudo-multithreading (eventlet greenlets) by committing before a query we refresh the state
+        of the connection so that it sees changes from other connections.
+        https://stackoverflow.com/questions/9305669/mysql-python-connection-does-not-see-changes-to-database-made
+        """
         connection = self._connection_pool.pop()
         connection.commit()
         return connection

--- a/mipengine/node/monetdb_interface/monet_db_facade.py
+++ b/mipengine/node/monetdb_interface/monet_db_facade.py
@@ -12,15 +12,11 @@ from mipengine.singleton import Singleton
 INTEGRITY_ERROR_RETRY_INTERVAL = 1
 BROKEN_PIPE_MAX_ATTEMPTS = 50
 BROKEN_PIPE_ERROR_RETRY = 0.2
-CREATE_OR_REPLACE_QUERY_TIMEOUT = 1
-CREATE_REMOTE_TABLE_QUERY_TIMEOUT = 1
-INSERT_INTO_QUERY_TIMEOUT = (
-    node_config.celery.worker_concurrency * node_config.celery.run_udf_time_limit
-)
+QUERY_EXECUTION_LOCK_TIMEOUT = node_config.celery.tasks_timeout
+UDF_EXECUTION_LOCK_TIMEOUT = node_config.celery.run_udf_task_timeout
 
-create_remote_table_query_lock = Semaphore()
-create_function_query_lock = Semaphore()
-insert_query_lock = Semaphore()
+query_execution_lock = Semaphore()
+udf_execution_lock = Semaphore()
 
 
 class DBExecutionDTO:
@@ -28,6 +24,12 @@ class DBExecutionDTO:
         self.query = query
         self.parameters = parameters
         self.many = many
+
+
+class LockDTO:
+    def __init__(self, lock, timeout):
+        self.lock = lock
+        self.timeout = timeout
 
 
 class _MonetDBConnectionPool(metaclass=Singleton):
@@ -39,7 +41,10 @@ class _MonetDBConnectionPool(metaclass=Singleton):
     """
 
     def __init__(self):
-        self._connection_pool = [self.create_connection() for _ in range(16)]
+        self._connection_pool = [
+            self.create_connection()
+            for _ in range(node_config.celery.worker_concurrency)
+        ]
 
     def create_connection(self):
         return pymonetdb.connect(
@@ -51,21 +56,17 @@ class _MonetDBConnectionPool(metaclass=Singleton):
         )
 
     def get_connection(self):
-        return self._connection_pool.pop()
+        connection = self._connection_pool.pop()
+        connection.commit()
+        return connection
 
-    def release_connection(self, conn):
-        self._connection_pool.append(conn)
+    def release_connection(self, connection):
+        connection.commit()
+        self._connection_pool.append(connection)
 
 
 @contextmanager
 def cursor(_connection):
-    """
-    We use pseudo-multithreading (eventlet greenlets) by committing before a select query we refresh the state
-    of the connection so that it sees changes from other connections.
-    https://stackoverflow.com/questions/9305669/mysql-python-connection-does-not-see-changes-to-database-made
-    """
-    _connection.commit()
-
     cur = _connection.cursor()
     yield cur
     cur.close()
@@ -83,9 +84,13 @@ def _execute_and_commit(conn, db_execution_dto):
 
 @contextmanager
 def _lock(query_lock, timeout):
-    query_lock.acquire(timeout=timeout)
-    yield
-    query_lock.release()
+    acquired = query_lock.acquire(timeout=timeout)
+    if not acquired:
+        raise TimeoutError()
+    try:
+        yield
+    finally:
+        query_lock.release()
 
 
 def db_execute_and_fetchall(query: str, parameters=None, many=False) -> List:
@@ -176,14 +181,25 @@ def _execute(query: str, parameters=None, many=False, conn=None):
         f"query: {db_execution_dto.query} \n, parameters: {str(db_execution_dto.parameters)}\n, many: {db_execution_dto.many}"
     )
 
-    if "CREATE OR REPLACE FUNCTION" in db_execution_dto.query:
-        with _lock(create_function_query_lock, CREATE_OR_REPLACE_QUERY_TIMEOUT):
+    lock_dto = (
+        LockDTO(udf_execution_lock, UDF_EXECUTION_LOCK_TIMEOUT)
+        if db_execution_dto.query.startswith("INSERT INTO")
+        else LockDTO(query_execution_lock, QUERY_EXECUTION_LOCK_TIMEOUT)
+    )
+
+    try:
+        with _lock(lock_dto.lock, lock_dto.timeout):
             _execute_and_commit(conn, db_execution_dto)
-    elif "CREATE REMOTE" in db_execution_dto.query:
-        with _lock(create_remote_table_query_lock, CREATE_REMOTE_TABLE_QUERY_TIMEOUT):
-            _execute_and_commit(conn, db_execution_dto)
-    elif "INSERT INTO" in db_execution_dto.query:
-        with _lock(insert_query_lock, INSERT_INTO_QUERY_TIMEOUT):
-            _execute_and_commit(conn, db_execution_dto)
-    else:
-        _execute_and_commit(conn, db_execution_dto)
+    except TimeoutError:
+        error_msg = _get_lock_timeout_error_msg(db_execution_dto, lock_dto.timeout)
+        raise TimeoutError(error_msg)
+
+
+def _get_lock_timeout_error_msg(db_execution_dto, lock_timeout):
+    return f"""
+        query: {db_execution_dto.query=} with parameters:
+        {str(db_execution_dto.parameters)} and
+        {db_execution_dto.many=} was not executed because the
+        lock was not acquired during
+        {lock_timeout=}
+    """

--- a/tasks.py
+++ b/tasks.py
@@ -138,6 +138,13 @@ def create_configs(c):
         node_config["rabbitmq"]["ip"] = deployment_config["ip"]
         node_config["rabbitmq"]["port"] = node["rabbitmq_port"]
 
+        node_config["celery"]["tasks_timeout"] = deployment_config[
+            "celery_tasks_timeout"
+        ]
+        node_config["celery"]["run_udf_task_timeout"] = deployment_config[
+            "celery_run_udf_task_timeout"
+        ]
+
         node_config["privacy"]["minimum_row_count"] = deployment_config["privacy"][
             "minimum_row_count"
         ]

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_globalnode.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode1.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_external_smpc_localnode2.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_globalnode.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnode1.toml
@@ -8,10 +8,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnode2.toml
@@ -8,10 +8,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_localnodetmp.toml
+++ b/tests/standalone_tests/testing_env_configs/test_localnodetmp.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_smpc_globalnode.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_globalnode.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_smpc_localnode1.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_localnode1.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"

--- a/tests/standalone_tests/testing_env_configs/test_smpc_localnode2.toml
+++ b/tests/standalone_tests/testing_env_configs/test_smpc_localnode2.toml
@@ -9,10 +9,8 @@ minimum_row_count = 10
 
 [celery]
 worker_concurrency = 16
-task_soft_time_limit = 30
-task_time_limit = 60
-run_udf_soft_time_limit = 30
-run_udf_time_limit = 60
+tasks_timeout = 120
+run_udf_task_timeout = 300
 
 [rabbitmq]
 ip = "172.17.0.1"


### PR DESCRIPTION
Changelog:
[jira-636](https://team-1617704806227.atlassian.net/jira/software/projects/MIP/boards/1?assignee=5f1826679d9a1200298e14bb&selectedIssue=MIP-636)
1.Refactored the configs for task timeout and udfs task timeout.
2. Now all non select queries are serialized.