### PR TITLE
SQL injection guard

### DIFF
--- a/mipengine/filters.py
+++ b/mipengine/filters.py
@@ -43,7 +43,7 @@ def build_filter_clause(rules):
         _check_condition(rules["condition"])
         cond = rules["condition"]
         rules = rules["rules"]
-        return f" {cond} ".join([build_filter_clause(rule) for rule in rules])
+        return "(" + f" {cond} ".join(build_filter_clause(rule) for rule in rules) + ")"
 
     if "id" in rules:
         column_name = rules["id"]

--- a/mipengine/filters.py
+++ b/mipengine/filters.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+import pymonetdb.sql.monetize as monetize
+
 from mipengine import DType
 from mipengine.node_tasks_DTOs import CommonDataElement
 
@@ -88,7 +90,9 @@ def validate_filter(data_model: str, rules: dict, cdes: Dict[str, CommonDataElem
 
 def _format_value_if_string(column_type, val):
     if column_type == "string":
-        return [f"'{item}'" for item in val] if isinstance(val, list) else f"'{val}'"
+        if isinstance(val, list):
+            return [monetize.convert(item) for item in val]
+        return monetize.convert(val)
     return val
 
 

--- a/mipengine/node/monetdb_interface/common_actions.py
+++ b/mipengine/node/monetdb_interface/common_actions.py
@@ -4,6 +4,9 @@ from typing import List
 
 from mipengine import DType
 from mipengine.exceptions import TablesNotFound
+from mipengine.node.monetdb_interface.guard import is_datamodel
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
 from mipengine.node_tasks_DTOs import ColumnInfo
@@ -69,6 +72,7 @@ def convert_schema_to_sql_query_format(schema: TableSchema) -> str:
     )
 
 
+@sql_injection_guard(table_name=is_lowercase_identifier)
 def get_table_schema(table_name: str) -> TableSchema:
     """
     Retrieves a schema for a specific table name from the monetdb.
@@ -107,6 +111,7 @@ def get_table_schema(table_name: str) -> TableSchema:
     )
 
 
+@sql_injection_guard(table_name=is_lowercase_identifier)
 def get_table_type(table_name: str) -> TableType:
     """
     Retrieves the type for a specific table name from the monetdb.
@@ -137,6 +142,7 @@ def get_table_type(table_name: str) -> TableType:
     return _convert_monet2mip_table_type(monetdb_table_type_result[0][0])
 
 
+@sql_injection_guard(table_type=None, context_id=str.isalnum)
 def get_table_names(table_type: TableType, context_id: str) -> List[str]:
     """
     Retrieves a list of table names, which contain the context_id from the monetdb.
@@ -165,6 +171,7 @@ def get_table_names(table_type: TableType, context_id: str) -> List[str]:
     return [table[0] for table in table_names]
 
 
+@sql_injection_guard(table_name=is_lowercase_identifier)
 def get_table_data(table_name: str) -> List[ColumnData]:
     """
     Returns a list of columns data which will contain name, type and the data of the specific column.
@@ -253,7 +260,8 @@ def get_data_models() -> List[str]:
     return data_models
 
 
-def get_dataset_code_per_dataset_label(data_model) -> Dict[str, str]:
+@sql_injection_guard(data_model=is_datamodel)
+def get_dataset_code_per_dataset_label(data_model: str) -> Dict[str, str]:
     """
     Retrieves the enabled key-value pair of code and label, for a specific data_model.
 
@@ -282,7 +290,8 @@ def get_dataset_code_per_dataset_label(data_model) -> Dict[str, str]:
     return datasets
 
 
-def get_data_model_cdes(data_model) -> CommonDataElements:
+@sql_injection_guard(data_model=is_datamodel)
+def get_data_model_cdes(data_model: str) -> CommonDataElements:
     """
     Retrieves the cdes of the specific data_model.
 
@@ -291,10 +300,11 @@ def get_data_model_cdes(data_model) -> CommonDataElements:
     CommonDataElements
         A CommonDataElements object
     """
+    data_model_code, data_model_version = data_model.split(":")
 
     cdes_rows = db_execute_and_fetchall(
         f"""
-        SELECT code, metadata FROM "{data_model}"."variables_metadata"
+        SELECT code, metadata FROM "{data_model_code}:{data_model_version}"."variables_metadata"
         """
     )
 
@@ -368,6 +378,7 @@ def _convert_mip2monet_table_type(table_type: TableType) -> int:
     return type_mapping.get(table_type)
 
 
+@sql_injection_guard(table_type=None, context_id=str.isalnum)
 def _drop_table_by_type_and_context_id(table_type: TableType, context_id: str):
     """
     Drops all tables of specific type with name that contain a specific context_id from the DB.
@@ -394,6 +405,7 @@ def _drop_table_by_type_and_context_id(table_type: TableType, context_id: str):
             db_execute(f"DROP TABLE {name}")
 
 
+@sql_injection_guard(context_id=str.isalnum)
 def _drop_udfs_by_context_id(context_id: str):
     """
     Drops all functions of specific context_id from the DB.

--- a/mipengine/node/monetdb_interface/common_actions.py
+++ b/mipengine/node/monetdb_interface/common_actions.py
@@ -5,7 +5,6 @@ from typing import List
 from mipengine import DType
 from mipengine.exceptions import TablesNotFound
 from mipengine.node.monetdb_interface.guard import is_datamodel
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
@@ -72,7 +71,7 @@ def convert_schema_to_sql_query_format(schema: TableSchema) -> str:
     )
 
 
-@sql_injection_guard(table_name=is_lowercase_identifier)
+@sql_injection_guard(table_name=str.isidentifier)
 def get_table_schema(table_name: str) -> TableSchema:
     """
     Retrieves a schema for a specific table name from the monetdb.
@@ -111,7 +110,7 @@ def get_table_schema(table_name: str) -> TableSchema:
     )
 
 
-@sql_injection_guard(table_name=is_lowercase_identifier)
+@sql_injection_guard(table_name=str.isidentifier)
 def get_table_type(table_name: str) -> TableType:
     """
     Retrieves the type for a specific table name from the monetdb.
@@ -171,7 +170,7 @@ def get_table_names(table_type: TableType, context_id: str) -> List[str]:
     return [table[0] for table in table_names]
 
 
-@sql_injection_guard(table_name=is_lowercase_identifier)
+@sql_injection_guard(table_name=str.isidentifier)
 def get_table_data(table_name: str) -> List[ColumnData]:
     """
     Returns a list of columns data which will contain name, type and the data of the specific column.

--- a/mipengine/node/monetdb_interface/guard.py
+++ b/mipengine/node/monetdb_interface/guard.py
@@ -1,0 +1,217 @@
+import inspect
+import re
+from functools import wraps
+from inspect import FullArgSpec
+from numbers import Number
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+from mipengine.node_tasks_DTOs import NodeLiteralDTO
+from mipengine.node_tasks_DTOs import NodeSMPCDTO
+from mipengine.node_tasks_DTOs import NodeTableDTO
+from mipengine.node_tasks_DTOs import NodeUDFDTO
+
+
+def sql_injection_guard(**validators: Optional[Callable[[Any], bool]]):
+    """
+    Parametrized  decorator guarding SQL generating functions from strings
+    suspect for SQL injections.
+
+    All  functions  that receive string arguments, sent from Controller to
+    Node  via  a  Celery  task,  should  be  decorated  with the decorator
+    returned   by  this  function.  This  function  accepts  only  keyword
+    arguments  which  should  be  one-to-one  with  the  arguments  of the
+    decorated  function.  For  each argument there should be one validator
+    function  or  None  for  arguments  which  don't  need validation. The
+    validator  function  is  a  predicate:  it receives a single value and
+    returns a bool.
+
+    Parameters
+    ----------
+    validators : Optional[Callable[[Any], bool]]
+        Validator functions, one for each argument of the decorated function
+
+    Examples
+    --------
+    >>> @sql_injection_guard(a=str.isalnum, b=my_validator, c=None)
+    ... def f(a, b, c):
+    ...     ...
+    """
+
+    def decorator(func):
+        argspec = inspect.getfullargspec(func)
+        if set(argspec.args) != set(validators.keys()):
+            raise ValueError(
+                "sql_injection_guard validators do not match function "
+                f"{func.__name__} args.\n"
+                f"Args mismatch: {set(argspec.args) - set(validators.keys())}.\n"
+                "Make sure to add one validator per function arg, passing "
+                "None for args that don't need validation."
+            )
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            values = get_arg_values(argspec, args, kwargs)
+            validate_arg_values(validators, values)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def get_arg_values(argspec: FullArgSpec, args: list, kwargs: dict) -> dict:
+    arg_values = get_named_defaults(argspec)
+    arg_values.update(get_named_posarg_values(argspec, args))
+    arg_values.update(kwargs)
+    return arg_values
+
+
+def get_named_defaults(argspec: FullArgSpec) -> dict:
+    if argspec.defaults:
+        return dict(zip(reversed(argspec.args), reversed(argspec.defaults)))
+    return {}
+
+
+def get_named_posarg_values(argspec: FullArgSpec, args: list) -> dict:
+    return dict(zip(argspec.args, args))
+
+
+def validate_arg_values(validators: dict, arg_values: dict) -> None:
+    for arg, value in arg_values.items():
+        validator = validators[arg] or (lambda x: True)
+        if not validator(value):
+            raise InvalidSQLParameter(
+                f"Arg '{arg}' with value '{value}' cannot be validated "
+                f"with validator '{validator.__name__}'."
+            )
+
+
+class InvalidSQLParameter(Exception):
+    pass
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Validators ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+
+# ip regex
+#   https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp
+# hostname regex (RFC 952)
+#   https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+ip_re = r"((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}"
+alpha_re = r"[a-zA-Z]"
+alnum_re = r"[a-zA-Z0-9]"
+alnumhyphen_re = r"[a-zA-Z0-9-]"
+hostname_re = rf"""(({alpha_re}|{alpha_re}{alnumhyphen_re}*{alnum_re})\.)*
+                    ({alpha_re}|{alpha_re}{alnumhyphen_re}*{alnum_re})"""
+port_re = r"(?P<port>\d{1,5})"
+socketaddress_ptrn = re.compile(rf"(?:{ip_re}|{hostname_re}):{port_re}", re.A | re.X)
+version_re = r"\w+(\.\w)*"
+datamodel_re = rf"\w+:{version_re}"
+datamodel_ptrn = re.compile(datamodel_re, re.A)
+sqlidentifier_re = r"[a-z_][a-z0-9_]*"
+datatable_ptrn = re.compile(rf'"{datamodel_re}"\.("\w+"|{sqlidentifier_re})', re.A)
+
+
+def is_lowercase_identifier(string):
+    return str.isidentifier(string) and str.islower(string)
+
+
+def is_socket_address(string):
+    match = socketaddress_ptrn.fullmatch(string)
+    if not match:
+        return False
+    port = int(match.group("port"))
+    if 1 <= port <= 65535:
+        return True
+    return False
+
+
+def is_datamodel(string):
+    return bool(datamodel_ptrn.fullmatch(string))
+
+
+def is_primary_data_table(string):
+    return is_lowercase_identifier(string) or bool(datatable_ptrn.fullmatch(string))
+
+
+def is_list_of_identifiers(lst):
+    return all(is_lowercase_identifier(s) for s in lst)
+
+
+def is_valid_filter(filter):
+    if filter is None:
+        return True
+    if "id" in filter:  # base case
+        return is_lowercase_identifier(filter["id"])
+    if "rules" in filter:  # recursive case
+        return all(is_valid_filter(rule) for rule in filter["rules"])
+    return False
+
+
+def is_valid_table_schema(schema):
+    return all(is_lowercase_identifier(col.name) for col in schema.columns)
+
+
+def is_valid_udf_arg(arg):
+    if isinstance(arg, NodeUDFDTO):
+        if isinstance(arg, NodeTableDTO):
+            return is_valid_table_dto(arg)
+        elif isinstance(arg, NodeSMPCDTO):
+            return is_valid_smpc_dto(arg)
+        elif isinstance(arg, NodeLiteralDTO):
+            return is_valid_literal_value(arg.value)
+        raise NotImplementedError(f"{arg.__class__} has no validator implementation")
+    raise TypeError("UDF args have to be subclasses of NodeUDFDTO")
+
+
+def is_valid_table_dto(dto):
+    return is_lowercase_identifier(dto.value)
+
+
+def is_valid_smpc_dto(dto):
+    return (
+        is_lowercase_identifier(dto.value.template.value)
+        and is_lowercase_identifier(dto.value.sum_op_values.value)
+        and is_lowercase_identifier(dto.value.min_op_values.value)
+        and is_lowercase_identifier(dto.value.max_op_values.value)
+    )
+
+
+def is_valid_literal_value(val):
+    if isinstance(val, Number):
+        return True
+    if isinstance(val, str):
+        # The  MonetDB  parser  has  a weird behaviour when parsing python UDFs.
+        # When  the  sequence '};' appears in a string in the python code, it is
+        # interpreted  as  the  end  of  the  UDF  definition. Weirdly, when the
+        # sequence is part of the actual code and not inside a string, it is not
+        # interpreted  like  that. This behaviour can be exploited to perform an
+        # SQL injection attack, passing for example the string '};DROP TABLE x;'
+        # as  a  literal.  To  avoid  that, these characters are prohibited from
+        # appearing in a literal string.
+        prohibited_chars = "};"
+        return not any(chr in val for chr in prohibited_chars)
+    if isinstance(val, list):
+        return all(is_valid_literal_value(elem) for elem in val)
+    if isinstance(val, dict):
+        return all(
+            is_valid_literal_value(k) and is_valid_literal_value(v)
+            for k, v in val.items()
+        )
+    raise NotImplementedError(
+        "Currently literal values can be of types str, Number, list or dict,\n"
+        "and nestings of the above."
+    )
+
+
+def udf_posargs_validator(posargs):
+    return all(is_valid_udf_arg(arg) for arg in posargs.args)
+
+
+def udf_kwargs_validator(kwargs):
+    return all(is_valid_udf_arg(arg) for _, arg in kwargs.args.items())
+
+
+def output_schema_validator(schema):
+    return schema is None or all(is_lowercase_identifier(name) for name, _ in schema)

--- a/mipengine/node/monetdb_interface/guard.py
+++ b/mipengine/node/monetdb_interface/guard.py
@@ -172,9 +172,21 @@ def is_valid_table_dto(dto):
 def is_valid_smpc_dto(dto):
     return (
         is_lowercase_identifier(dto.value.template.value)
-        and is_lowercase_identifier(dto.value.sum_op_values.value)
-        and is_lowercase_identifier(dto.value.min_op_values.value)
-        and is_lowercase_identifier(dto.value.max_op_values.value)
+        and (
+            is_lowercase_identifier(dto.value.sum_op_values.value)
+            if dto.value.sum_op_values
+            else True
+        )
+        and (
+            is_lowercase_identifier(dto.value.min_op_values.value)
+            if dto.value.min_op_values
+            else True
+        )
+        and (
+            is_lowercase_identifier(dto.value.max_op_values.value)
+            if dto.value.max_op_values
+            else True
+        )
     )
 
 

--- a/mipengine/node/monetdb_interface/guard.py
+++ b/mipengine/node/monetdb_interface/guard.py
@@ -113,10 +113,6 @@ sqlidentifier_re = r"[a-z_][a-z0-9_]*"
 datatable_ptrn = re.compile(rf'"{datamodel_re}"\.("\w+"|{sqlidentifier_re})', re.A)
 
 
-def is_lowercase_identifier(string):
-    return str.isidentifier(string) and str.islower(string)
-
-
 def is_socket_address(string):
     match = socketaddress_ptrn.fullmatch(string)
     if not match:
@@ -132,25 +128,25 @@ def is_datamodel(string):
 
 
 def is_primary_data_table(string):
-    return is_lowercase_identifier(string) or bool(datatable_ptrn.fullmatch(string))
+    return string.isidentifier() or bool(datatable_ptrn.fullmatch(string))
 
 
 def is_list_of_identifiers(lst):
-    return all(is_lowercase_identifier(s) for s in lst)
+    return all(s.isidentifier() for s in lst)
 
 
 def is_valid_filter(filter):
     if filter is None:
         return True
     if "id" in filter:  # base case
-        return is_lowercase_identifier(filter["id"])
+        return filter["id"].isidentifier()
     if "rules" in filter:  # recursive case
         return all(is_valid_filter(rule) for rule in filter["rules"])
     return False
 
 
 def is_valid_table_schema(schema):
-    return all(is_lowercase_identifier(col.name) for col in schema.columns)
+    return all(col.name.isidentifier() for col in schema.columns)
 
 
 def is_valid_udf_arg(arg):
@@ -166,24 +162,24 @@ def is_valid_udf_arg(arg):
 
 
 def is_valid_table_dto(dto):
-    return is_lowercase_identifier(dto.value)
+    return dto.value.isidentifier()
 
 
 def is_valid_smpc_dto(dto):
     return (
-        is_lowercase_identifier(dto.value.template.value)
+        dto.value.template.value.isidentifier()
         and (
-            is_lowercase_identifier(dto.value.sum_op_values.value)
+            dto.value.sum_op_values.value.isidentifier()
             if dto.value.sum_op_values
             else True
         )
         and (
-            is_lowercase_identifier(dto.value.min_op_values.value)
+            dto.value.min_op_values.value.isidentifier()
             if dto.value.min_op_values
             else True
         )
         and (
-            is_lowercase_identifier(dto.value.max_op_values.value)
+            dto.value.max_op_values.value.isidentifier()
             if dto.value.max_op_values
             else True
         )
@@ -226,4 +222,4 @@ def udf_kwargs_validator(kwargs):
 
 
 def output_schema_validator(schema):
-    return schema is None or all(is_lowercase_identifier(name) for name, _ in schema)
+    return schema is None or all(name.isidentifier() for name, _ in schema)

--- a/mipengine/node/monetdb_interface/merge_tables.py
+++ b/mipengine/node/monetdb_interface/merge_tables.py
@@ -10,7 +10,6 @@ from mipengine.node.monetdb_interface.common_actions import (
 )
 from mipengine.node.monetdb_interface.common_actions import get_table_names
 from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import is_valid_table_schema
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
@@ -23,16 +22,14 @@ def get_merge_tables_names(context_id: str) -> List[str]:
     return get_table_names(TableType.MERGE, context_id)
 
 
-@sql_injection_guard(
-    table_name=is_lowercase_identifier, table_schema=is_valid_table_schema
-)
+@sql_injection_guard(table_name=str.isidentifier, table_schema=is_valid_table_schema)
 def create_merge_table(table_name: str, table_schema: TableSchema):
     columns_schema = convert_schema_to_sql_query_format(table_schema)
     db_execute(f"CREATE MERGE TABLE {table_name} ( {columns_schema} )")
 
 
 @sql_injection_guard(
-    merge_table_name=is_lowercase_identifier,
+    merge_table_name=str.isidentifier,
     table_names=is_list_of_identifiers,
 )
 def add_to_merge_table(merge_table_name: str, table_names: List[str]):

--- a/mipengine/node/monetdb_interface/merge_tables.py
+++ b/mipengine/node/monetdb_interface/merge_tables.py
@@ -9,6 +9,10 @@ from mipengine.node.monetdb_interface.common_actions import (
     convert_schema_to_sql_query_format,
 )
 from mipengine.node.monetdb_interface.common_actions import get_table_names
+from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import is_valid_table_schema
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
 from mipengine.node_tasks_DTOs import TableSchema
@@ -19,6 +23,9 @@ def get_merge_tables_names(context_id: str) -> List[str]:
     return get_table_names(TableType.MERGE, context_id)
 
 
+@sql_injection_guard(
+    table_name=is_lowercase_identifier, table_schema=is_valid_table_schema
+)
 def create_merge_table(table_name: str, table_schema: TableSchema):
     columns_schema = convert_schema_to_sql_query_format(table_schema)
     db_execute(f"CREATE MERGE TABLE {table_name} ( {columns_schema} )")
@@ -33,6 +40,10 @@ def get_non_existing_tables(table_names: List[str]) -> List[str]:
     return [name for name in table_names if name not in existing_table_names]
 
 
+@sql_injection_guard(
+    merge_table_name=is_lowercase_identifier,
+    table_names=is_list_of_identifiers,
+)
 def add_to_merge_table(merge_table_name: str, table_names: List[str]):
     try:
         for name in table_names:
@@ -45,6 +56,7 @@ def add_to_merge_table(merge_table_name: str, table_names: List[str]):
             raise exc
 
 
+@sql_injection_guard(table_names=is_list_of_identifiers)
 def validate_tables_can_be_merged(table_names: List[str]):
     names_clause = ",".join(f"'{table}'" for table in table_names)
     existing_table_names_and_types = db_execute_and_fetchall(

--- a/mipengine/node/monetdb_interface/merge_tables.py
+++ b/mipengine/node/monetdb_interface/merge_tables.py
@@ -31,15 +31,6 @@ def create_merge_table(table_name: str, table_schema: TableSchema):
     db_execute(f"CREATE MERGE TABLE {table_name} ( {columns_schema} )")
 
 
-def get_non_existing_tables(table_names: List[str]) -> List[str]:
-    names_clause = str(table_names)[1:-1]
-    existing_tables = db_execute_and_fetchall(
-        f"SELECT name FROM tables WHERE name IN ({names_clause})"
-    )
-    existing_table_names = [table[0] for table in existing_tables]
-    return [name for name in table_names if name not in existing_table_names]
-
-
 @sql_injection_guard(
     merge_table_name=is_lowercase_identifier,
     table_names=is_list_of_identifiers,

--- a/mipengine/node/monetdb_interface/remote_tables.py
+++ b/mipengine/node/monetdb_interface/remote_tables.py
@@ -5,7 +5,12 @@ from mipengine.node.monetdb_interface.common_actions import (
     convert_schema_to_sql_query_format,
 )
 from mipengine.node.monetdb_interface.common_actions import get_table_names
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import is_socket_address
+from mipengine.node.monetdb_interface.guard import is_valid_table_schema
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
+from mipengine.node_tasks_DTOs import TableSchema
 from mipengine.node_tasks_DTOs import TableType
 
 
@@ -13,7 +18,12 @@ def get_remote_table_names(context_id: str) -> List[str]:
     return get_table_names(TableType.REMOTE, context_id)
 
 
-def create_remote_table(name, schema, monetdb_socket_address: str):
+@sql_injection_guard(
+    name=is_lowercase_identifier,
+    monetdb_socket_address=is_socket_address,
+    schema=is_valid_table_schema,
+)
+def create_remote_table(name: str, schema: TableSchema, monetdb_socket_address: str):
     columns_schema = convert_schema_to_sql_query_format(schema)
     db_execute(
         f"""

--- a/mipengine/node/monetdb_interface/remote_tables.py
+++ b/mipengine/node/monetdb_interface/remote_tables.py
@@ -5,7 +5,6 @@ from mipengine.node.monetdb_interface.common_actions import (
     convert_schema_to_sql_query_format,
 )
 from mipengine.node.monetdb_interface.common_actions import get_table_names
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import is_socket_address
 from mipengine.node.monetdb_interface.guard import is_valid_table_schema
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
@@ -19,7 +18,7 @@ def get_remote_table_names(context_id: str) -> List[str]:
 
 
 @sql_injection_guard(
-    name=is_lowercase_identifier,
+    name=str.isidentifier,
     monetdb_socket_address=is_socket_address,
     schema=is_valid_table_schema,
 )

--- a/mipengine/node/monetdb_interface/tables.py
+++ b/mipengine/node/monetdb_interface/tables.py
@@ -5,6 +5,9 @@ from mipengine.node.monetdb_interface import common_actions
 from mipengine.node.monetdb_interface.common_actions import (
     convert_schema_to_sql_query_format,
 )
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import is_valid_table_schema
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
 from mipengine.node_tasks_DTOs import TableSchema
 from mipengine.node_tasks_DTOs import TableType
@@ -14,12 +17,15 @@ def get_table_names(context_id: str) -> List[str]:
     return common_actions.get_table_names(TableType.NORMAL, context_id)
 
 
+@sql_injection_guard(
+    table_name=is_lowercase_identifier, table_schema=is_valid_table_schema
+)
 def create_table(table_name: str, table_schema: TableSchema):
     columns_schema = convert_schema_to_sql_query_format(table_schema)
     db_execute(f"CREATE TABLE {table_name} ( {columns_schema} )")
 
 
-# TODO:Should validate the arguments, will be fixed with pydantic
+@sql_injection_guard(table_name=is_lowercase_identifier, table_values=None)
 def insert_data_to_table(
     table_name: str, table_values: List[List[Union[str, int, float]]]
 ):

--- a/mipengine/node/monetdb_interface/tables.py
+++ b/mipengine/node/monetdb_interface/tables.py
@@ -5,7 +5,6 @@ from mipengine.node.monetdb_interface import common_actions
 from mipengine.node.monetdb_interface.common_actions import (
     convert_schema_to_sql_query_format,
 )
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import is_valid_table_schema
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
@@ -17,15 +16,13 @@ def get_table_names(context_id: str) -> List[str]:
     return common_actions.get_table_names(TableType.NORMAL, context_id)
 
 
-@sql_injection_guard(
-    table_name=is_lowercase_identifier, table_schema=is_valid_table_schema
-)
+@sql_injection_guard(table_name=str.isidentifier, table_schema=is_valid_table_schema)
 def create_table(table_name: str, table_schema: TableSchema):
     columns_schema = convert_schema_to_sql_query_format(table_schema)
     db_execute(f"CREATE TABLE {table_name} ( {columns_schema} )")
 
 
-@sql_injection_guard(table_name=is_lowercase_identifier, table_values=None)
+@sql_injection_guard(table_name=str.isidentifier, table_values=None)
 def insert_data_to_table(
     table_name: str, table_values: List[List[Union[str, int, float]]]
 ):

--- a/mipengine/node/monetdb_interface/views.py
+++ b/mipengine/node/monetdb_interface/views.py
@@ -5,7 +5,6 @@ from mipengine.filters import build_filter_clause
 from mipengine.node import config as node_config
 from mipengine.node.monetdb_interface.common_actions import get_table_names
 from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import is_primary_data_table
 from mipengine.node.monetdb_interface.guard import is_valid_filter
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
@@ -21,7 +20,7 @@ def get_view_names(context_id: str) -> List[str]:
 
 
 @sql_injection_guard(
-    view_name=is_lowercase_identifier,
+    view_name=str.isidentifier,
     table_name=is_primary_data_table,
     columns=is_list_of_identifiers,
     filters=is_valid_filter,

--- a/mipengine/node/monetdb_interface/views.py
+++ b/mipengine/node/monetdb_interface/views.py
@@ -4,6 +4,11 @@ from mipengine.exceptions import InsufficientDataError
 from mipengine.filters import build_filter_clause
 from mipengine.node import config as node_config
 from mipengine.node.monetdb_interface.common_actions import get_table_names
+from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import is_primary_data_table
+from mipengine.node.monetdb_interface.guard import is_valid_filter
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
 from mipengine.node_tasks_DTOs import TableType
@@ -15,6 +20,13 @@ def get_view_names(context_id: str) -> List[str]:
     return get_table_names(TableType.VIEW, context_id)
 
 
+@sql_injection_guard(
+    view_name=is_lowercase_identifier,
+    table_name=is_primary_data_table,
+    columns=is_list_of_identifiers,
+    filters=is_valid_filter,
+    check_min_rows=None,
+)
 def create_view(
     view_name: str,
     table_name: str,

--- a/mipengine/node/tasks/udfs.py
+++ b/mipengine/node/tasks/udfs.py
@@ -11,7 +11,6 @@ from mipengine.node.monetdb_interface import udfs
 from mipengine.node.monetdb_interface.common_actions import create_table_name
 from mipengine.node.monetdb_interface.common_actions import get_table_schema
 from mipengine.node.monetdb_interface.common_actions import get_table_type
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import output_schema_validator
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
 from mipengine.node.monetdb_interface.guard import udf_kwargs_validator
@@ -456,7 +455,7 @@ def convert_udfgen2udf_results_and_mapping(
     request_id=str.isalnum,
     command_id=str.isalnum,
     context_id=str.isalnum,
-    func_name=is_lowercase_identifier,
+    func_name=str.isidentifier,
     positional_args=udf_posargs_validator,
     keyword_args=udf_kwargs_validator,
     use_smpc=None,

--- a/mipengine/node_tasks_DTOs.py
+++ b/mipengine/node_tasks_DTOs.py
@@ -10,8 +10,6 @@ from pydantic import BaseModel
 from pydantic import validator
 
 from mipengine import DType
-
-# ~~~~~~~~~~~~~~~~~~~~ Enums ~~~~~~~~~~~~~~~~~~~~ #
 from mipengine.table_data_DTOs import ColumnDataBinary
 from mipengine.table_data_DTOs import ColumnDataFloat
 from mipengine.table_data_DTOs import ColumnDataInt
@@ -19,6 +17,7 @@ from mipengine.table_data_DTOs import ColumnDataJSON
 from mipengine.table_data_DTOs import ColumnDataStr
 
 
+# ~~~~~~~~~~~~~~~~~~~~ Enums ~~~~~~~~~~~~~~~~~~~~ #
 class _NodeUDFDTOType(enum.Enum):
     TABLE = "TABLE"
     LITERAL = "LITERAL"
@@ -38,15 +37,6 @@ class TableType(enum.Enum):
         return self.name
 
 
-# ~~~~~~~~~~~~~~~~~~ Validator ~~~~~~~~~~~~~~~~~ #
-
-
-def validate_identifier(identifier):
-    if not identifier.isidentifier():
-        raise ValueError(f"Expected valid identifier, got {identifier}")
-    return identifier
-
-
 # ~~~~~~~~~~~~~~~~~~~ DTOs ~~~~~~~~~~~~~~~~~~~~~~ #
 
 
@@ -59,8 +49,6 @@ class ColumnInfo(ImmutableBaseModel):
     name: str
     dtype: DType
 
-    _validate_identifier = validator("name", allow_reuse=True)(validate_identifier)
-
 
 class TableSchema(ImmutableBaseModel):
     columns: List[ColumnInfo]
@@ -70,8 +58,6 @@ class TableInfo(ImmutableBaseModel):
     name: str
     schema_: TableSchema
     type_: TableType
-
-    _validate_identifier = validator("name", allow_reuse=True)(validate_identifier)
 
 
 class TableData(ImmutableBaseModel):

--- a/tests/standalone_tests/test_filters.py
+++ b/tests/standalone_tests/test_filters.py
@@ -120,7 +120,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_age_value = 17",
+        "(test_age_value = 17)",
     ),
     (
         {
@@ -137,7 +137,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_pupil_reactivity_right_eye_result <> 'Nonreactive'",
+        "(test_pupil_reactivity_right_eye_result <> 'Nonreactive')",
     ),
     (
         {
@@ -162,7 +162,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_age_value = 17 OR test_pupil_reactivity_right_eye_result <> 'Nonreactive'",
+        "(test_age_value = 17 OR test_pupil_reactivity_right_eye_result <> 'Nonreactive')",
     ),
     (
         {
@@ -187,7 +187,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_age_value < 50 AND test_age_value > 20",
+        "(test_age_value < 50 AND test_age_value > 20)",
     ),
     (
         {
@@ -212,7 +212,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "NOT test_age_value BETWEEN 60 AND 90 AND test_mortality_core BETWEEN 0.3 AND 0.8",
+        "(NOT test_age_value BETWEEN 60 AND 90 AND test_mortality_core BETWEEN 0.3 AND 0.8)",
     ),
     (
         {
@@ -237,7 +237,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_gose_score IS NULL OR test_gcs_total_score IS NOT NULL",
+        "(test_gose_score IS NULL OR test_gcs_total_score IS NOT NULL)",
     ),
     (
         {
@@ -254,7 +254,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_age_value IN (17,19)",
+        "(test_age_value IN (17,19))",
     ),
     (
         {
@@ -271,7 +271,7 @@ all_success_cases = [
             ],
             "valid": True,
         },
-        "test_gender_type IN ('F','M')",
+        "(test_gender_type IN ('F','M'))",
     ),
     (
         {
@@ -349,8 +349,7 @@ all_success_cases = [
             "valid": True,
         },
         (
-            "test_gender_type = 'F' AND test_age_value BETWEEN 20 AND 30 AND test_gose_score IS NOT NULL OR test_gender_type <> 'F' AND "
-            "test_mortality_core > 0.5 AND test_mortality_core <= 0.8"
+            "((test_gender_type = 'F' AND (test_age_value BETWEEN 20 AND 30 AND test_gose_score IS NOT NULL)) OR (test_gender_type <> 'F' AND (test_mortality_core > 0.5 AND test_mortality_core <= 0.8)))"
         ),
     ),
 ]

--- a/tests/standalone_tests/test_guard.py
+++ b/tests/standalone_tests/test_guard.py
@@ -1,0 +1,219 @@
+from collections import namedtuple
+
+import pytest
+
+from mipengine.node.monetdb_interface.guard import InvalidSQLParameter
+from mipengine.node.monetdb_interface.guard import is_datamodel
+from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
+from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
+from mipengine.node.monetdb_interface.guard import is_primary_data_table
+from mipengine.node.monetdb_interface.guard import is_socket_address
+from mipengine.node.monetdb_interface.guard import is_valid_filter
+from mipengine.node.monetdb_interface.guard import is_valid_literal_value
+from mipengine.node.monetdb_interface.guard import is_valid_table_schema
+from mipengine.node.monetdb_interface.guard import sql_injection_guard
+
+
+def test_is_lowercase_identifier_valid():
+    assert is_lowercase_identifier("some_name_1")
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "SomeName",
+        "1some_name",
+        "some.name",
+    ],
+)
+def test_is_lowercase_identifier_invalid(string):
+    assert not is_lowercase_identifier(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "0.0.0.0:1",
+        "192.168.1.1:50000",
+        "255.255.255.255:65535",
+    ],
+)
+def test_is_socket_address_valid(string):
+    assert is_socket_address(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "0.0.0.0:0",
+        "192.168.1:50000",
+        " 192.168.1.1:50000",
+        "192.168.1.1:50000 ",
+        "192.168.1.1",
+        "255.255.255.256:65535",
+        "255.255.255.255:65536",
+    ],
+)
+def test_is_socket_address_invalid(string):
+    assert not is_socket_address(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "datamodel:0",
+        "datamodel:0.1",
+        "datamodel:alpha",
+        "datamodel:alpha_beta",
+        "data_model_1:0.1",
+    ],
+)
+def test_is_datamodel_valid(string):
+    assert is_datamodel(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "datamodel",
+        "datamodel:",
+        ":0.1",
+        "datamodel:.0",
+        "datamodel:0.",
+    ],
+)
+def test_is_datamodel_invalid(string):
+    assert not is_datamodel(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "data_table",
+        '"datamodel:0.1".data_table',
+        '"datamodel:0.1"."Data_Table"',
+    ],
+)
+def test_is_primary_data_table_valid(string):
+    assert is_primary_data_table(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "data table",
+        '"datamodel:0.1".Data_Table',
+        '"datamodel:0.1".',
+        '"datamodel:0.1"."Data Table"',
+    ],
+)
+def test_is_primary_data_table_invalid(string):
+    assert not is_primary_data_table(string)
+
+
+def test_is_list_of_identifiers():
+    assert is_list_of_identifiers(["name_1", "name_2"])
+    assert not is_list_of_identifiers(["Name_1", "name_2"])
+
+
+def test_is_valid_filter():
+    assert is_valid_filter({"rules": [{"id": "name"}, {"rules": [{"id": "name"}]}]})
+    assert not is_valid_filter({"rules": [{"id": "name"}, {"rules": [{"id": "Name"}]}]})
+
+
+def test_is_valid_table_schema():
+    Column = namedtuple("Column", "name")
+    Schema = namedtuple("Schema", "columns")
+
+    valid_schema = Schema(columns=[Column(name="name_1"), Column(name="name_2")])
+    invalid_schema = Schema(columns=[Column(name="name_1"), Column(name="Name_2")])
+
+    assert is_valid_table_schema(valid_schema)
+    assert not is_valid_table_schema(invalid_schema)
+
+
+def test_sql_injection_guard__validate_posarg():
+    @sql_injection_guard(a=str.isalpha)
+    def f(a):
+        pass
+
+    try:
+        f("a")
+    except InvalidSQLParameter as exc:
+        pytest.fail(f"Unexpected exception {exc}")
+
+
+def test_sql_injection_guard__validate_kwarg():
+    @sql_injection_guard(a=str.isalpha)
+    def f(a):
+        pass
+
+    try:
+        f(a="a")
+    except InvalidSQLParameter as exc:
+        pytest.fail(f"Unexpected exception {exc}")
+
+
+def test_sql_injection_guard__validate_default():
+    @sql_injection_guard(a=str.isalpha)
+    def f(a="a"):
+        pass
+
+    try:
+        f()
+    except InvalidSQLParameter as exc:
+        pytest.fail(f"Unexpected exception {exc}")
+
+
+def test_sql_injection_guard__missing_validator():
+    def f(a, b):
+        pass
+
+    with pytest.raises(ValueError):
+        sql_injection_guard(a=None)(f)
+
+
+def test_sql_injection_guard__missing_param():
+    def f(a):
+        pass
+
+    with pytest.raises(ValueError):
+        sql_injection_guard(a=None, b=None)(f)
+
+
+def test_sql_injection_guard__raise_invalid_parameter():
+    @sql_injection_guard(a=str.isalnum)
+    def f(a):
+        pass
+
+    with pytest.raises(InvalidSQLParameter):
+        f(a="!")
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        1,
+        "a",
+        ["a", "b"],
+        {"a": "b", "c": 1},
+        [{"a": "b"}],
+        {"a": ["b"]},
+    ],
+)
+def test_is_valid_literal_value__valid(val):
+    assert is_valid_literal_value(val)
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        "};",
+        ["}", ";"],
+        {"}": ";"},
+        [{"}": ";"}],
+        {"}": [";"]},
+    ],
+)
+def test_is_valid_literal_value__invalid(val):
+    assert not is_valid_literal_value(val)

--- a/tests/standalone_tests/test_guard.py
+++ b/tests/standalone_tests/test_guard.py
@@ -5,29 +5,12 @@ import pytest
 from mipengine.node.monetdb_interface.guard import InvalidSQLParameter
 from mipengine.node.monetdb_interface.guard import is_datamodel
 from mipengine.node.monetdb_interface.guard import is_list_of_identifiers
-from mipengine.node.monetdb_interface.guard import is_lowercase_identifier
 from mipengine.node.monetdb_interface.guard import is_primary_data_table
 from mipengine.node.monetdb_interface.guard import is_socket_address
 from mipengine.node.monetdb_interface.guard import is_valid_filter
 from mipengine.node.monetdb_interface.guard import is_valid_literal_value
 from mipengine.node.monetdb_interface.guard import is_valid_table_schema
 from mipengine.node.monetdb_interface.guard import sql_injection_guard
-
-
-def test_is_lowercase_identifier_valid():
-    assert is_lowercase_identifier("some_name_1")
-
-
-@pytest.mark.parametrize(
-    "string",
-    [
-        "SomeName",
-        "1some_name",
-        "some.name",
-    ],
-)
-def test_is_lowercase_identifier_invalid(string):
-    assert not is_lowercase_identifier(string)
 
 
 @pytest.mark.parametrize(
@@ -113,12 +96,14 @@ def test_is_primary_data_table_invalid(string):
 
 def test_is_list_of_identifiers():
     assert is_list_of_identifiers(["name_1", "name_2"])
-    assert not is_list_of_identifiers(["Name_1", "name_2"])
+    assert not is_list_of_identifiers(["name.1", "name_2"])
 
 
 def test_is_valid_filter():
-    assert is_valid_filter({"rules": [{"id": "name"}, {"rules": [{"id": "name"}]}]})
-    assert not is_valid_filter({"rules": [{"id": "name"}, {"rules": [{"id": "Name"}]}]})
+    assert is_valid_filter({"rules": [{"id": "name1"}, {"rules": [{"id": "name2"}]}]})
+    assert not is_valid_filter(
+        {"rules": [{"id": "name1"}, {"rules": [{"id": "name.2"}]}]}
+    )
 
 
 def test_is_valid_table_schema():
@@ -126,7 +111,7 @@ def test_is_valid_table_schema():
     Schema = namedtuple("Schema", "columns")
 
     valid_schema = Schema(columns=[Column(name="name_1"), Column(name="name_2")])
-    invalid_schema = Schema(columns=[Column(name="name_1"), Column(name="Name_2")])
+    invalid_schema = Schema(columns=[Column(name="name_1"), Column(name="name.2")])
 
     assert is_valid_table_schema(valid_schema)
     assert not is_valid_table_schema(invalid_schema)

--- a/tests/standalone_tests/test_node_tasks_dtos.py
+++ b/tests/standalone_tests/test_node_tasks_dtos.py
@@ -91,17 +91,6 @@ def test_table_data_with_different_column_types():
     assert TableData.parse_raw(data.json()) == data
 
 
-# validation check for TableSchema with error
-def test_table_schema_sql_injection_error():
-    with pytest.raises(ValidationError):
-        ColumnInfo(name="Robert'); DROP TABLE data; --", dtype=DType.FLOAT)
-
-
-def test_table_schema_type_error():
-    with pytest.raises(ValidationError):
-        ColumnInfo(name=123, dtype=DType.FLOAT)
-
-
 def test_table_schema_immutable():
     schema = TableSchema(
         columns=[


### PR DESCRIPTION
- Implement `sql_injection_guard` and add to all SQL generating functions in `monetdb_interface`
- Sanitize strings appearing in `WHERE` clause of SQL queries, in `filters.py`
- Fix missing parentheses bug in `filters.py`
- Remove SQL injection checks from pydantic models 