### PR TITLE
SMPC Standalone tests in github actions won't run if the non smpc tests fail

### DIFF
--- a/.github/workflows/standalone_tests.yml
+++ b/.github/workflows/standalone_tests.yml
@@ -122,13 +122,14 @@ jobs:
           run: docker logs smpc_test_player3
 
       - name: Run all standalone tests except the SMPC
+        id: non_smpc_tests
         run: poetry run pytest -s -m "not smpc" --cov=mipengine --cov-report=xml:non_smpc_cov.xml tests/standalone_tests --verbosity=4
 
-      - name: Cleanup running containers to have resources for the SMPC tests
-        run: poetry run inv cleanup
-
-      - name: Run SMPC specific standalone tests
-        run: poetry run pytest -s -m "smpc" --cov=mipengine --cov-report=xml:smpc_cov.xml tests/standalone_tests --verbosity=4
+      - name: Run SMPC specific standalone tests after releasing previous test resources
+        if: success() || ( failure() && steps.non_smpc_tests.outcome == 'failure' )
+        run:  |
+          poetry run inv cleanup
+          poetry run pytest -s -m "smpc" --cov=mipengine --cov-report=xml:smpc_cov.xml tests/standalone_tests --verbosity=4
 
       - name: Publish coverage on codeclimate
         uses: paambaati/codeclimate-action@v2.7.5


### PR DESCRIPTION
Changelog:
  - Fix for smpc standalone tests not running if the non-smpc tests fail. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-686)