### PR TITLE
Dev/mip 697/monetdb memory limit in k8s and liveness probe

### DIFF
--- a/kubernetes/docs/ImportNodeData.md
+++ b/kubernetes/docs/ImportNodeData.md
@@ -3,7 +3,7 @@
 ### Setting up the data
 
 Before the data manager can load data in a local node, the data should be located
-in the `csvs_datapath` location provided in the kubernetes `values.yaml`.
+in the `db.csvs_location` provided in the kubernetes `values.yaml`.
 
 That folder should contain the metadata of the data model that will be loaded and the dataset csvs.
 

--- a/kubernetes/docs/NodeDataBackup.md
+++ b/kubernetes/docs/NodeDataBackup.md
@@ -14,11 +14,11 @@ kubectl get pods -o wide
 kubectl exec -i <pod_id> -c monetdb -- sh -c 'msqldump --database=db > $MONETDB_STORAGE/db.sql'
 ```
 
-The global/local Node data are stored in the `db_storage` path defined in the [helm chart values](../values.yaml). This is the same for all the nodes.
+The global/local Node data are stored in the `db.storage_location` path defined in the [helm chart values](../values.yaml). This is the same for all the nodes.
 
 #### In order to restore the instance of the database:
 
-1. Move the database snapshot to your local storage `db_storage` path defined in the [helm chart values](../values.yaml).
+1. Move the database snapshot to your local storage `db.storage_location` path defined in the [helm chart values](../values.yaml).
 
 1. Get the pod id of the node to restore:
 

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -22,11 +22,14 @@ spec:
       volumes:
       - name: db-data
         hostPath:
-          path: {{ .Values.db_storage }}
+          path: {{ .Values.db.storage_location }}
       containers:
       - name: monetdb
         image: {{ .Values.mipengine_images.repository }}/mipenginedb:{{ .Values.mipengine_images.version }}
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: {{ quote .Values.db.max_memory }}
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -64,6 +64,15 @@ spec:
           value: "30"
         ports:
           - containerPort: 5672
+        livenessProbe:
+          exec:
+            command:
+              - rabbitmq-diagnostics
+              - -q
+              - check_port_connectivity
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
 
       - name: node
         image: {{ .Values.mipengine_images.repository }}/mipengine_node:{{ .Values.mipengine_images.version }}

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -40,6 +40,15 @@ spec:
         volumeMounts:
         - mountPath: /home/monetdb
           name: db-data
+        livenessProbe:
+          exec:
+            command:
+            - mclient
+            - db
+            - -s
+            - "select name from sys.tables;"
+          initialDelaySeconds: 30
+          periodSeconds: 30
 
       - name: rabbitmq
         image: {{ .Values.mipengine_images.repository }}/mipengine_rabbitmq:{{ .Values.mipengine_images.version }}

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -31,14 +31,17 @@ spec:
       volumes:
       - name: db-data
         hostPath:
-          path: {{ .Values.db_storage }}
+          path: {{ .Values.db.storage_location }}
       - name: csv-data
         hostPath:
-          path: {{ .Values.csvs_datapath }}
+          path: {{ .Values.db.csvs_location }}
       containers:
       - name: monetdb
         image: {{ .Values.mipengine_images.repository }}/mipenginedb:{{ .Values.mipengine_images.version }}
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: {{ quote .Values.db.max_memory }}
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -50,6 +50,15 @@ spec:
         volumeMounts:
         - mountPath: /home/monetdb
           name: db-data
+        livenessProbe:
+          exec:
+            command:
+            - mclient
+            - db
+            - -s
+            - "select name from sys.tables;"
+          initialDelaySeconds: 30
+          periodSeconds: 30
 
       - name: db-importer
         image: {{ .Values.mipengine_images.repository }}/mipengine_mipdb:{{ .Values.mipengine_images.version }}

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -88,6 +88,15 @@ spec:
           value: "30"
         ports:
           - containerPort: 5672
+        livenessProbe:
+          exec:
+            command:
+              - rabbitmq-diagnostics
+              - -q
+              - check_port_connectivity
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
 
       - name: node
         image: {{ .Values.mipengine_images.repository }}/mipengine_node:{{ .Values.mipengine_images.version }}

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -9,8 +9,10 @@ framework_log_level: INFO
 
 max_concurrent_experiments: 32
 
-db_storage: /opt/mipengine/db
-csvs_datapath: /opt/mipengine/csvs
+db:
+  storage_location: /opt/mipengine/db
+  csvs_location: /opt/mipengine/csvs
+  max_memory: 1024Mi    # k8s memory limit
 
 controller:
   node_landscape_aggregator_update_interval: 30

--- a/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
+++ b/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
@@ -9,8 +9,10 @@ framework_log_level: INFO
 
 max_concurrent_experiments: 32
 
-db_storage: /opt/mipengine/db
-csvs_datapath: /opt/mipengine/csvs
+db:
+  storage_location: /opt/mipengine/db
+  csvs_location: /opt/mipengine/csvs
+  max_memory: 1024Mi    # k8s memory limit
 
 controller:
   node_landscape_aggregator_update_interval: 20

--- a/tests/smpc_env_tests/deployment_configs/kubernetes_values.yaml
+++ b/tests/smpc_env_tests/deployment_configs/kubernetes_values.yaml
@@ -7,8 +7,10 @@ mipengine_images:
 log_level: DEBUG
 framework_log_level: INFO
 
-db_storage: /opt/mipengine/db
-csvs_datapath: /opt/mipengine/csvs
+db:
+  storage_location: /opt/mipengine/db
+  csvs_location: /opt/mipengine/csvs
+  max_memory: 1024Mi    # k8s memory limit
 
 controller:
   node_landscape_aggregator_update_interval: 30


### PR DESCRIPTION
Changelog:
  - Added memory limit on k8s monetdb container. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-697)
  - Added liveness probe in the same monetdb container.
  - Added liveness probe in the rabbitmq container.