### PR TITLE
Fix/algorithm validation tests same url usage

### DIFF
--- a/tests/algorithm_validation_tests/helpers.py
+++ b/tests/algorithm_validation_tests/helpers.py
@@ -32,6 +32,15 @@ def algorithm_request(algorithm: str, input: dict):
 
     headers = {"Content-type": "application/json", "Accept": "text/plain"}
     response = requests.post(url, data=request_json, headers=headers)
+    if response.status_code != 200:
+        raise ValueError(
+            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
+        )
+    try:
+        json.loads(response.content)
+    except json.decoder.JSONDecodeError as exc:
+        print(response)
+        raise exc
     return response
 
 

--- a/tests/algorithm_validation_tests/helpers.py
+++ b/tests/algorithm_validation_tests/helpers.py
@@ -12,10 +12,8 @@ def algorithm_request(algorithm: str, input: dict):
 
     variables = copy.deepcopy(input["inputdata"]["y"])
     keys = input["inputdata"].keys()
-    if "x" in keys:
+    if "x" in keys and input["inputdata"]["x"]:
         variables.extend(input["inputdata"]["x"])
-    else:
-        pass
 
     filters = {
         "condition": "AND",

--- a/tests/algorithm_validation_tests/test_anova_oneway_validation.py
+++ b/tests/algorithm_validation_tests/test_anova_oneway_validation.py
@@ -3,47 +3,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import requests
 
-from tests.prod_env_tests import algorithms_url
+from tests.algorithm_validation_tests.helpers import algorithm_request
 
 expected_file = Path(__file__).parent / "expected" / "anova_oneway_expected.json"
-
-
-def anova_one_way_request(input):
-    url = algorithms_url + "/anova_oneway"
-
-    filters = {
-        "condition": "AND",
-        "rules": [
-            {
-                "id": "dataset",
-                "type": "string",
-                "value": input["inputdata"]["datasets"],
-                "operator": "in",
-            },
-            {
-                "condition": "AND",
-                "rules": [
-                    {
-                        "id": variable,
-                        "type": "string",
-                        "operator": "is_not_null",
-                        "value": None,
-                    }
-                    for variable in input["inputdata"]["x"] + input["inputdata"]["y"]
-                ],
-            },
-        ],
-        "valid": True,
-    }
-    input["inputdata"]["filters"] = filters
-    # input["inputdata"]["use_smpc"] = False
-    request_json = json.dumps(input)
-
-    headers = {"Content-type": "application/json", "Accept": "text/plain"}
-    response = requests.post(url, data=request_json, headers=headers)
-    return response
 
 
 def get_test_params(file, slc=None):
@@ -57,7 +20,8 @@ def get_test_params(file, slc=None):
 
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_anova_algorithm(test_input, expected):
-    response = anova_one_way_request(test_input)
+    response = algorithm_request("anova_oneway", test_input)
+
     if response.status_code != 200:
         raise ValueError(
             f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"

--- a/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
@@ -48,14 +48,7 @@ def get_cached_response(algorithm_name, test_input, cache):
 )
 def test_linearregression_cv_non_inferiority_msre(test_input, expected, cache):
     response = get_cached_response("linear_regression_cv", test_input, cache)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
-    try:
-        result = json.loads(response.text)
-    except json.decoder.JSONDecodeError:
-        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+    result = json.loads(response.content)
 
     n_splits = test_input["parameters"]["n_splits"]
     msre_res_mean, msre_res_std = result["mean_sq_error"]

--- a/tests/algorithm_validation_tests/test_linearregression_validation.py
+++ b/tests/algorithm_validation_tests/test_linearregression_validation.py
@@ -13,14 +13,7 @@ expected_file = Path(__file__).parent / "expected" / "linear_regression_expected
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_linearregression_algorithm(test_input, expected):
     response = algorithm_request("linear_regression", test_input)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
-    try:
-        result = json.loads(response.text)
-    except json.decoder.JSONDecodeError:
-        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+    result = json.loads(response.content)
 
     assert result["dependent_var"] == expected["dependent_var"]
     assert result["indep_vars"] == expected["indep_vars"]

--- a/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
@@ -25,10 +25,7 @@ expected_file = (
 )
 def test_logisticregression_cv_algorithm(test_input, expected, subtests):
     response = algorithm_request("logistic_regression_cv", test_input)
-    try:
-        result = json.loads(response.text)
-    except json.decoder.JSONDecodeError:
-        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+    result = json.loads(response.content)
 
     # summary results also contain their average and stdev in the last
     # positions, so I remove them

--- a/tests/algorithm_validation_tests/test_logisticregression_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_validation.py
@@ -14,14 +14,7 @@ expected_file = Path(__file__).parent / "expected" / "logistic_regression_expect
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_logisticregression_algorithm(test_input, expected, subtests):
     response = algorithm_request("logistic_regression", test_input)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
-    try:
-        result = json.loads(response.text)
-    except json.decoder.JSONDecodeError:
-        raise ValueError(f"The result is not valid json:\n{response.text}") from None
+    result = json.loads(response.content)
 
     result = result["summary"]
 

--- a/tests/algorithm_validation_tests/test_one_sample.py
+++ b/tests/algorithm_validation_tests/test_one_sample.py
@@ -14,10 +14,6 @@ expected_file = Path(__file__).parent / "expected" / "one_sample_expected.json"
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_one_sample_ttest(test_input, expected):
     response = algorithm_request("ttest_onesample", test_input)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
     result = json.loads(response.content)
 
     assert_allclose(result["n_obs"], expected["n_obs"], rtol=1e-8, atol=1e-10)

--- a/tests/algorithm_validation_tests/test_paired_ttest.py
+++ b/tests/algorithm_validation_tests/test_paired_ttest.py
@@ -13,10 +13,6 @@ expected_file = Path(__file__).parent / "expected" / "paired_ttest_expected.json
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_paired_ttest(test_input, expected):
     response = algorithm_request("ttest_paired", test_input)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
     result = json.loads(response.content)
 
     assert_allclose(result["t_stat"], expected["statistic"], rtol=1e-8, atol=1e-10)

--- a/tests/algorithm_validation_tests/test_paired_ttest.py
+++ b/tests/algorithm_validation_tests/test_paired_ttest.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import numpy as np
 import pytest
 
 from tests.algorithm_validation_tests.helpers import algorithm_request

--- a/tests/algorithm_validation_tests/test_pca_validation.py
+++ b/tests/algorithm_validation_tests/test_pca_validation.py
@@ -5,19 +5,9 @@ import numpy as np
 import pytest
 import requests
 
+from tests.algorithm_validation_tests.helpers import algorithm_request
+
 expected_file = Path(__file__).parent / "expected" / "pca_expected.json"
-
-
-def pca_request(input):
-    url = "http://127.0.0.1:5000/algorithms" + "/pca"
-
-    filters = None
-    input["inputdata"]["filters"] = filters
-    request_json = json.dumps(input)
-
-    headers = {"Content-type": "application/json", "Accept": "text/plain"}
-    response = requests.post(url, data=request_json, headers=headers)
-    return response
 
 
 def get_test_params(expected_file, slc=None):
@@ -31,7 +21,8 @@ def get_test_params(expected_file, slc=None):
 
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_pca_algorithm(test_input, expected):
-    response = pca_request(test_input)
+    response = algorithm_request("pca", test_input)
+
     if response.status_code != 200:
         raise ValueError(
             f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"

--- a/tests/algorithm_validation_tests/test_pca_validation.py
+++ b/tests/algorithm_validation_tests/test_pca_validation.py
@@ -22,14 +22,8 @@ def get_test_params(expected_file, slc=None):
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_pca_algorithm(test_input, expected):
     response = algorithm_request("pca", test_input)
-
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
     result = json.loads(response.content)
 
-    assert response.status_code == 200
     assert int(result["n_obs"]) == int(expected["n_obs"])
     np.testing.assert_allclose(
         result["eigenvalues"],

--- a/tests/algorithm_validation_tests/test_pearson_correlation_validation.py
+++ b/tests/algorithm_validation_tests/test_pearson_correlation_validation.py
@@ -23,16 +23,8 @@ def get_test_params(expected_file, slc=None):
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_pearson_algorithm(test_input, expected):
     response = algorithm_request("pearson_correlation", test_input)
-    if response.status_code != 200:
-        raise ValueError(
-            f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"
-        )
-    try:
-        result = json.loads(response.content)
-    except json.decoder.JSONDecodeError as exc:
-        print(response)
-        raise exc
-    assert response.status_code == 200
+    result = json.loads(response.content)
+
     assert int(result["n_obs"]) == int(expected["n_obs"])
     for var in test_input["inputdata"]["y"]:
         np.testing.assert_allclose(

--- a/tests/algorithm_validation_tests/test_pearson_correlation_validation.py
+++ b/tests/algorithm_validation_tests/test_pearson_correlation_validation.py
@@ -6,23 +6,9 @@ import numpy as np
 import pytest
 import requests
 
+from tests.algorithm_validation_tests.helpers import algorithm_request
+
 expected_file = Path(__file__).parent / "expected" / "pearson_correlation_expected.json"
-
-
-def pearson_request(input):
-    url = "http://127.0.0.1:5000/algorithms" + "/pearson_correlation"
-
-    variables = copy.deepcopy(input["inputdata"]["y"])
-    if input["inputdata"]["x"]:
-        variables.extend(input["inputdata"]["x"])
-
-    filters = None
-    input["inputdata"]["filters"] = filters
-    request_json = json.dumps(input)
-
-    headers = {"Content-type": "application/json", "Accept": "text/plain"}
-    response = requests.post(url, data=request_json, headers=headers)
-    return response
 
 
 def get_test_params(expected_file, slc=None):
@@ -36,7 +22,7 @@ def get_test_params(expected_file, slc=None):
 
 @pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
 def test_pearson_algorithm(test_input, expected):
-    response = pearson_request(test_input)
+    response = algorithm_request("pearson_correlation", test_input)
     if response.status_code != 200:
         raise ValueError(
             f"Unexpected response status: '{response.status_code}'. Response message: '{response.content}'"


### PR DESCRIPTION
Changelog:
  - All algorithm validation tests now use the 'algorithm_request' method.
  - Unified exc handling in the 'algorithm_request' method of algo tests.