### PR TITLE
MIP-689 Pass min_row_count in udfs

### DIFF
--- a/mipengine/node/tasks/udfs.py
+++ b/mipengine/node/tasks/udfs.py
@@ -498,6 +498,7 @@ def _generate_udf_statements(
         {
             "udf_name": udf_name,
             "node_id": node_config.identifier,
+            "min_row_count": node_config.privacy.minimum_row_count,
         }
     )
     udf_statements = _create_udf_statements(udf_execution_queries, templates_mapping)

--- a/mipengine/udfgen/__init__.py
+++ b/mipengine/udfgen/__init__.py
@@ -1,4 +1,5 @@
 from .udfgenerator import DEFERRED
+from .udfgenerator import MIN_ROW_COUNT
 from .udfgenerator import TensorBinaryOp
 from .udfgenerator import TensorUnaryOp
 from .udfgenerator import generate_udf_queries
@@ -32,4 +33,5 @@ __all__ = [
     "TensorBinaryOp",
     "make_unique_func_name",
     "DEFERRED",
+    "MIN_ROW_COUNT",
 ]

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -798,6 +798,11 @@ def placeholder(name):
     return PlaceholderType(name)
 
 
+# special type for passing MIN_ROW_COUNT in UDF. Only Node knows the actual
+# value so here it's exported as a placeholder and replaced by Node.
+MIN_ROW_COUNT = placeholder("min_row_count")
+
+
 class TableType(ABC):
     @property
     @abstractmethod

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -771,6 +771,33 @@ def udf_logger():
     return UDFLoggerType()
 
 
+class PlaceholderType(InputType):
+    def __init__(self, name):
+        self.name = "$" + name
+
+
+def placeholder(name):
+    """
+    UDF input type factory for inserting an assignment to arbitrary an
+    placeholder in UDF definition.
+
+    Examples
+    --------
+    Using this function in the udf decorator, as show below
+
+    >>> @udf(x=placeholder("some_name"))
+    ... def f(x):
+    ...    pass
+
+    will insert the line
+
+        x = $some_name
+
+    in the SQL UDF definition.
+    """
+    return PlaceholderType(name)
+
+
 class TableType(ABC):
     @property
     @abstractmethod
@@ -984,6 +1011,15 @@ class UDFLoggerArg(UDFArgument):
     def __init__(self, request_id, udf_name):
         self.request_id = request_id
         self.udf_name = udf_name
+
+
+class PlaceholderArg(UDFArgument):
+    def __init__(self, type):
+        self.type = type
+
+    @property
+    def name(self):
+        return self.type.name
 
 
 class TableArg(UDFArgument, ABC):
@@ -1325,6 +1361,16 @@ class LoggerAssignment(ASTNode):
         return f"{name} = udfio.get_logger('{logger_arg.udf_name}', '{logger_arg.request_id}')"
 
 
+class PlaceholderAssignments(ASTNode):
+    def __init__(self, placeholders):
+        self.placeholders = placeholders
+
+    def compile(self) -> str:
+        return LN.join(
+            f"{name} = {arg.name}" for name, arg in self.placeholders.items()
+        )
+
+
 class UDFBodyStatements(ASTNode):
     def __init__(self, statements):
         self.returnless_stmts = [
@@ -1344,6 +1390,7 @@ class UDFBody(ASTNode):
         smpc_args: Dict[str, SMPCSecureTransferArg],
         literal_args: Dict[str, LiteralArg],
         logger_arg: Optional[Tuple[str, UDFLoggerArg]],
+        placeholder_args: Dict[str, PlaceholderArg],
         statements: list,
         main_return_name: str,
         main_return_type: OutputType,
@@ -1364,6 +1411,7 @@ class UDFBody(ASTNode):
         self.smpc_builds = SMPCBuilds(smpc_args)
         self.literals = LiteralAssignments(literal_args)
         self.logger = LoggerAssignment(logger_arg)
+        self.placeholders = PlaceholderAssignments(placeholder_args)
         all_types = (
             [arg.type for arg in table_args.values()]
             + [main_return_type]
@@ -1388,6 +1436,7 @@ class UDFBody(ASTNode):
                     self.smpc_builds.compile(),
                     self.literals.compile(),
                     self.logger.compile(),
+                    self.placeholders.compile(),
                     self.returnless_stmts.compile(),
                     self.loopback_return_stmts.compile(),
                     self.return_stmt.compile(),
@@ -1442,6 +1491,7 @@ class UDFDefinition(ASTNode):
         smpc_args: Dict[str, SMPCSecureTransferArg],
         literal_args: Dict[str, LiteralArg],
         logger_arg: Optional[Tuple[str, UDFLoggerArg]],
+        placeholder_args: Dict[str, PlaceholderArg],
         main_output_type: OutputType,
         sec_output_types: List[OutputType],
         smpc_used: bool,
@@ -1457,6 +1507,7 @@ class UDFDefinition(ASTNode):
             smpc_args=smpc_args,
             literal_args=literal_args,
             logger_arg=logger_arg,
+            placeholder_args=placeholder_args,
             statements=funcparts.body_statements,
             main_return_name=funcparts.main_return_name,
             main_return_type=main_output_type,
@@ -2229,6 +2280,14 @@ def get_udf_args(request_id, funcparts, posargs, keywordargs) -> Dict[str, UDFAr
             request_id=request_id,
             udf_name=funcparts.qualname,
         )
+    placeholders = get_items_of_type(PlaceholderType, funcparts.sig.parameters)
+    if placeholders:
+        udf_args.update(
+            {
+                name: PlaceholderArg(type=placeholder)
+                for name, placeholder in placeholders.items()
+            }
+        )
     return udf_args
 
 
@@ -2334,6 +2393,7 @@ def get_udf_definition_template(
     logger_param = funcparts.logger_param_name
     if logger_param:
         logger_arg = (logger_param, input_args[logger_param])
+    placeholder_args = get_items_of_type(PlaceholderArg, input_args)
 
     verify_declared_and_passed_param_types_match(
         funcparts.table_input_types, table_args
@@ -2344,6 +2404,7 @@ def get_udf_definition_template(
         smpc_args=smpc_args,
         literal_args=literal_args,
         logger_arg=logger_arg,
+        placeholder_args=placeholder_args,
         main_output_type=main_output_type,
         sec_output_types=sec_output_types,
         smpc_used=smpc_used,

--- a/tests/algorithm_validation_tests/five_node_deployment_template.toml
+++ b/tests/algorithm_validation_tests/five_node_deployment_template.toml
@@ -14,7 +14,7 @@ celery_cleanup_task_timeout=2
 celery_run_udf_task_timeout = 300
 
 [privacy]
-minimum_row_count = 0
+minimum_row_count = 1
 
 [cleanup]
 nodes_cleanup_interval=30

--- a/tests/algorithm_validation_tests/one_node_deployment_template.toml
+++ b/tests/algorithm_validation_tests/one_node_deployment_template.toml
@@ -14,7 +14,7 @@ celery_cleanup_task_timeout=2
 celery_run_udf_task_timeout = 120
 
 [privacy]
-minimum_row_count = 0
+minimum_row_count = 1
 
 [cleanup]
 nodes_cleanup_interval=30

--- a/tests/algorithm_validation_tests/test_anova_oneway_validation.py
+++ b/tests/algorithm_validation_tests/test_anova_oneway_validation.py
@@ -12,7 +12,14 @@ algorithm_name = "anova_oneway"
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"
 
 
-@pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
+@pytest.mark.parametrize(
+    "test_input, expected",
+    get_test_params(
+        expected_file,
+        skip_indices=[10, 13, 19],
+        skip_reason="Awaiting https://team-1617704806227.atlassian.net/browse/MIP-698",
+    ),
+)
 def test_anova_algorithm(test_input, expected):
     response = algorithm_request(algorithm_name, test_input)
 

--- a/tests/algorithm_validation_tests/test_logisticregression_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_validation.py
@@ -13,7 +13,14 @@ algorithm_name = "logistic_regression"
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"
 
 
-@pytest.mark.parametrize("test_input, expected", get_test_params(expected_file))
+@pytest.mark.parametrize(
+    "test_input, expected",
+    get_test_params(
+        expected_file,
+        skip_indices=[13],
+        skip_reason="Awaiting https://team-1617704806227.atlassian.net/browse/MIP-698",
+    ),
+)
 def test_logisticregression_algorithm(test_input, expected, subtests):
     response = algorithm_request(algorithm_name, test_input)
     result = json.loads(response.content)


### PR DESCRIPTION
- Add new `placeholder` input type factory to UDF generator (see documentation).
- Add `MIN_ROW_COUNT` as special case of the above type, to allow this value to be passed in UDFs. This feature targets specifically _Descriptive Statistics_ and _Histograms_, which are the only algorithms that must use this value internally (closes [MIP-689](https://team-1617704806227.atlassian.net/browse/MIP-689)).
- `min_row_count` is now equal to 1 in algorithm validation tests.