### PR TITLE
reenable test_anova_oneway_validation skipped parametrized tests

### DIFF
--- a/tests/algorithm_validation_tests/test_anova_oneway_validation.py
+++ b/tests/algorithm_validation_tests/test_anova_oneway_validation.py
@@ -14,11 +14,7 @@ expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected
 
 @pytest.mark.parametrize(
     "test_input, expected",
-    get_test_params(
-        expected_file,
-        skip_indices=[10, 13, 19],
-        skip_reason="Awaiting https://team-1617704806227.atlassian.net/browse/MIP-698",
-    ),
+    get_test_params(expected_file),
 )
 def test_anova_algorithm(test_input, expected):
     response = algorithm_request(algorithm_name, test_input)


### PR DESCRIPTION
There where some more tests that were disabled because of [MIP-698](https://team-1617704806227.atlassian.net/browse/MIP-698) but were not mentioned in the ticket