### PR TITLE
algorithms: reduce memory footprint of local UDFs

### DIFF
--- a/mipengine/algorithms/anova_oneway.py
+++ b/mipengine/algorithms/anova_oneway.py
@@ -115,14 +115,14 @@ def local1(y, x, covar_enums):
     import numpy as np
     import pandas as pd
 
-    variable = y.reset_index(drop=True).to_numpy().squeeze()
-    covariable = x.reset_index(drop=True).to_numpy().squeeze()
+    y.reset_index(drop=True)
+    x.reset_index(drop=True)
+    variable = y.to_numpy().squeeze()
+    covariable = x.to_numpy().squeeze()
     var_label = y.columns.values.tolist()[0]
     covar_label = x.columns.values.tolist()[0]
     covar_enums = np.array(covar_enums)
-    dataset = pd.DataFrame()
-    dataset[var_label] = variable
-    dataset[covar_label] = covariable
+    dataset = pd.DataFrame({var_label: variable, covar_label: covariable}, copy=False)
 
     n_obs = y.shape[0]
     min_per_group = dataset.groupby([covar_label]).min()

--- a/mipengine/algorithms/linear_regression.py
+++ b/mipengine/algorithms/linear_regression.py
@@ -206,10 +206,12 @@ class LinearRegression:
         return_type=secure_transfer(sum_op=True),
     )
     def _compute_summary_local(y_test, y_pred):
-        rss = sum((y_test - y_pred) ** 2)
-        sum_y_test = sum(y_test)
-        sum_sq_y_test = sum(y_test**2)
-        sum_abs_resid = sum(abs(y_test - y_pred))
+        adiff = numpy.subtract(y_test, y_pred)
+        adiff = numpy.fabs(adiff, out=adiff)
+        rss = numpy.einsum("i,i", adiff, adiff)
+        sum_y_test = numpy.einsum("i->", y_test)
+        sum_sq_y_test = numpy.einsum("i,i", y_test, y_test)
+        sum_abs_resid = numpy.einsum("i->", adiff)
         n_obs_test = len(y_test)
 
         stransfer = {}

--- a/mipengine/algorithms/logistic_regression.py
+++ b/mipengine/algorithms/logistic_regression.py
@@ -146,10 +146,10 @@ class LogisticRegression:
         # However, this generates a large (n_obs, n_obs) diagonal matrix.
         # Instead, the version using Einstein summation is memory efficient
         # thanks to the optimized tensor constraction algorithms behind einsum.
-        H = numpy.einsum("ji, j..., jk -> ik", X, w, X, optimize="greedy")
+        H = numpy.einsum("ji, j, jk -> ik", X, w.squeeze(), X)
 
         # gradient
-        grad = numpy.einsum("ji, j... -> i", X, y - mu, optimize="greedy")
+        grad = numpy.einsum("ji, j -> i", X, (y - mu).squeeze())
 
         # log-likelihood
         ll = numpy.sum(special.xlogy(y, mu) + special.xlogy(1 - y, 1 - mu))

--- a/mipengine/algorithms/pearson_correlation.py
+++ b/mipengine/algorithms/pearson_correlation.py
@@ -102,11 +102,11 @@ def local1(y, x):
     Y = y.to_numpy()
     X = Y if x is None else x.to_numpy()
 
-    sx = X.sum(axis=0)
-    sy = Y.sum(axis=0)
-    sxx = (X**2).sum(axis=0)
-    sxy = (X.T @ Y).T
-    syy = (Y**2).sum(axis=0)
+    sx = numpy.einsum("ij->j", X)
+    sy = numpy.einsum("ij->j", Y)
+    sxx = numpy.einsum("ij,ij->j", X, X)
+    sxy = numpy.einsum("ji,jk->ki", X, Y)
+    syy = numpy.einsum("ij,ij->j", Y, Y)
 
     transfer_ = {}
     transfer_["n_obs"] = {"data": n_obs, "operation": "sum", "type": "int"}

--- a/mipengine/algorithms/ttest_independent.py
+++ b/mipengine/algorithms/ttest_independent.py
@@ -66,14 +66,15 @@ def run(algo_interface):
     return_type=[secure_transfer(sum_op=True)],
 )
 def local_independent(x, y):
-    x1 = x.reset_index(drop=True).to_numpy().squeeze()
-    x2 = y.reset_index(drop=True).to_numpy().squeeze()
+    x.reset_index(drop=True, inplace=True)
+    y.reset_index(drop=True, inplace=True)
+    x1, x2 = x.values.squeeze(), y.values.squeeze()
     x1_sum = sum(x1)
     x2_sum = sum(x2)
     n_obs_x1 = len(x)
     n_obs_x2 = len(y)
-    x1_sqrd_sum = sum(x1**2)
-    x2_sqrd_sum = sum(x2**2)
+    x1_sqrd_sum = numpy.einsum("i,i->", x1, x1)
+    x2_sqrd_sum = numpy.einsum("i,i->", x2, x2)
 
     sec_transfer_ = {
         "n_obs_x1": {"data": n_obs_x1, "operation": "sum", "type": "int"},

--- a/mipengine/algorithms/ttest_onesample.py
+++ b/mipengine/algorithms/ttest_onesample.py
@@ -72,12 +72,13 @@ def run(algo_interface):
     return_type=[secure_transfer(sum_op=True)],
 )
 def local_one_sample(x, mu):
-    x = x.reset_index(drop=True).to_numpy().squeeze()
+    x.reset_index(drop=True, inplace=True)
+    x = x.to_numpy().squeeze()
     n_obs = len(x)
-    sum_x = sum(x)
-    sqrd_x = sum(x**2)
-    diff_x = sum(x - mu)
-    diff_sqrd_x = sum((x - mu) ** 2)
+    sum_x = numpy.einsum("i->", x)
+    sqrd_x = numpy.einsum("i,i->", x, x)
+    diff_x = sum_x - n_obs * mu
+    diff_sqrd_x = sqrd_x - 2 * mu * sum_x + n_obs * mu**2
 
     sec_transfer_ = {
         "n_obs": {"data": n_obs, "operation": "sum", "type": "int"},

--- a/mipengine/algorithms/ttest_paired.py
+++ b/mipengine/algorithms/ttest_paired.py
@@ -64,22 +64,24 @@ def run(algo_interface):
     return_type=[secure_transfer(sum_op=True)],
 )
 def local_paired(x, y):
-    x1 = x.reset_index(drop=True).to_numpy().squeeze()
-    x2 = y.reset_index(drop=True).to_numpy().squeeze()
-    x1_sum = sum(x1)
-    x2_sum = sum(x2)
-    n_obs = len(x)
-    diff = sum(x1 - x2)
-    diff_sqrd = sum((x1 - x2) ** 2)
-    x1_sqrd_sum = sum(x1**2)
-    x2_sqrd_sum = sum(x2**2)
+    x.reset_index(drop=True, inplace=True)
+    y.reset_index(drop=True, inplace=True)
+    x1, x2 = x.values.squeeze(), y.values.squeeze()
+    x1_sum = numpy.einsum("i->", x1)
+    x2_sum = numpy.einsum("i->", x2)
+    n_obs = x.shape[0]
+    diff = x1 - x2
+    sd = numpy.einsum("i->", diff)
+    ssd = numpy.einsum("i,i", diff, diff)
+    x1_sqrd_sum = numpy.einsum("i,i", x1, x1)
+    x2_sqrd_sum = numpy.einsum("i,i", x2, x2)
 
     sec_transfer_ = {
         "n_obs": {"data": n_obs, "operation": "sum", "type": "int"},
         "sum_x1": {"data": x1_sum.item(), "operation": "sum", "type": "float"},
         "sum_x2": {"data": x2_sum.item(), "operation": "sum", "type": "float"},
-        "diff": {"data": diff.tolist(), "operation": "sum", "type": "float"},
-        "diff_sqrd": {"data": diff_sqrd.tolist(), "operation": "sum", "type": "float"},
+        "diff": {"data": sd.tolist(), "operation": "sum", "type": "float"},
+        "diff_sqrd": {"data": ssd.tolist(), "operation": "sum", "type": "float"},
         "x1_sqrd_sum": {
             "data": x1_sqrd_sum.tolist(),
             "operation": "sum",

--- a/mipengine/udfgen/udfio.py
+++ b/mipengine/udfgen/udfio.py
@@ -55,7 +55,7 @@ def from_tensor_table(table: dict):
 
 
 def from_relational_table(table: dict, row_id: str):
-    result = pd.DataFrame(table)
+    result = pd.DataFrame(table, copy=False)
     if row_id in result.columns:
         return result.set_index(row_id)
     return result


### PR DESCRIPTION
Some memory expensive lines are identified, in local UDFs, and are replaced with equivalent memory efficient ones.

All changes fall into three categories:
- Avoid memory copies when operation can be done inplace
- Use of `numpy.einsum`, when applicable, for summing over arrays
- Avoid using `sklearn` methods when re-implementing is easy, because `sklearn` hasn't been written with the above two considerations in mind

There is also one change in `udfio.py`. When constructing a `pandas.DataFrame` from separate columns, for relational tables, the flag `copy=False` is now used. This avoids consolidating columns into a single 2-dimensional array. **However, when some operation, later in the UDF, requires the columns to be consolidated, `pandas` will eventually do it in the background, copying their data into a single contiguous block of memory. This is unavoidable since many operations in `numpy` need to operate on contiguous blocks of memory in order to maximize their efficiency, since they exploit the CPU cache and the CPU vectorization capabilities.**

In most cases the memory reduction is accompanied by a reduction in execution time as well.

Results are presented in the next table

| file                     | method                                    | data  | mem before | mem after | perc | time before | time after | perc |
| ----------------------   | ----------------------------------------- | ----- | ---------- | --------- | ---------- | ----------- | ---------- | ---------- |
| `pca.py`                 | `local1`                                  | 160MB | 172MB      | 2KB       | 0.001%     | 250ms       | 30ms       | 12%        |
| `pca.py`                 | `local2`                                  | 160MB | 305MB      | 153MB     | 50%        | 300ms       | 400ms      | 133%       |
| `pearson.py`             | `local1`                                  | 320MB | 153MB      | 5KB       | 0.003%     | 330ms       | 300ms      | 90%        |
| `ttest_independent.py`   | `local_independet`                        | 16MB  | 24MB       | 3KB       | 0.012%     | 360ms       | 190ms      | 53%        |
| `ttest_onesample.py`     | `local_one_sample`                        | 8MB   | 16MB       | 3KB       | 0.018%     | 380ms       | 800μs      | 0.21%      |
| `ttest_paired.py`        | `local_paired`                            | 16MB  | 24MB       | 8MB       | 33%        | 600ms       | 4ms        | 0.67%      |
| `metrics.py`             | `_confusion_matrix_local`                 | 16MB  | 44MB       | 2MB       | 4.5%       | 140ms       | 6ms        | 4.3%       |
| `metrics.py`             | `_roc_curve_local`                        | 16MB  | 1.6GB      | 2MB       | 0.12%      | 2.7s        | 600ms      | 22%        |
| `logistic_regression.py` | `LogistcRegression._fit_local_step`       | 24MB  | 24MB       | 8KB       | 0.32%      | 23ms        | 233ms      | 1000%      |
| `linear_regression.py`   | `LinearRegression._compute_summary_local` | 16MB  | 8MB        | 8MB       | 100%       | 360ms       | 5ms        | 1.3%       |
| `anova_oneway.py`        | `local1`                                  | 16MB  | 106MB      | 74MB      | 70%        | 200ms       | 100ms      | 50%        | 
| `destriptive_stats.py`   | `local`                                   | 168MB | 424MB      | 358MB     | 84%        | 6s          | 5.8s       | 97%        |
| `udfio.py`               | `from_relational_table`                   | 2GB   | 2GB        | 8KB       | ~0%        | 1.6s        | 150μs      | 0.009%     |


