### PR TITLE
MIP-721 Table creating retry fails if there was a broken pipe error.

### DIFF
--- a/mipengine/node/tasks/merge_tables.py
+++ b/mipengine/node/tasks/merge_tables.py
@@ -60,11 +60,11 @@ def create_merge_table(
         context_id,
         command_id,
     )
-    # The schema of the 1st table is used as the merge table schema.
-    # If there is an incompatibility or a table doesn't exist the db will throw an error.
-    merge_tables.create_merge_table(merge_table_name, table_infos[0].schema_)
-    merge_tables.add_to_merge_table(
-        merge_table_name, [table_info.name for table_info in table_infos]
+
+    merge_tables.create_merge_table(
+        table_name=merge_table_name,
+        table_schema=table_infos[0].schema_,
+        merge_table_names=[table_info.name for table_info in table_infos],
     )
 
     return TableInfo(

--- a/mipengine/node/tasks/udfs.py
+++ b/mipengine/node/tasks/udfs.py
@@ -258,7 +258,6 @@ def _convert_table_result_to_udf_statements(
     result: UDFGenTableResult, templates_mapping: dict
 ) -> List[str]:
     return [
-        result.drop_query.substitute(**templates_mapping),
         result.create_query.substitute(**templates_mapping),
     ]
 

--- a/mipengine/node/tasks/views.py
+++ b/mipengine/node/tasks/views.py
@@ -16,6 +16,8 @@ from mipengine.node.node_logger import initialise_logger
 from mipengine.node_tasks_DTOs import TableInfo
 from mipengine.node_tasks_DTOs import TableType
 
+MINIMUM_ROW_COUNT = node_config.privacy.minimum_row_count
+
 
 @shared_task
 @initialise_logger
@@ -128,6 +130,7 @@ def create_data_model_view(
         table_name=f'"{data_model}"."primary_data"',
         columns=columns,
         filters=filters,
+        minimum_row_count=MINIMUM_ROW_COUNT,
         check_min_rows=check_min_rows,
     )
 
@@ -240,4 +243,5 @@ def create_view(
         table_name=table_name,
         columns=columns,
         filters=filters,
+        minimum_row_count=MINIMUM_ROW_COUNT,
     ).json()

--- a/mipengine/udfgen/udfgen_DTOs.py
+++ b/mipengine/udfgen/udfgen_DTOs.py
@@ -21,15 +21,12 @@ class UDFGenResult(UDFGenBaseModel):
 class UDFGenTableResult(UDFGenResult):
     tablename_placeholder: str
     table_schema: List[Tuple[str, DType]]
-    drop_query: Template
     create_query: Template
 
     def __eq__(self, other):
         if self.tablename_placeholder != other.tablename_placeholder:
             return False
         if self.table_schema != other.table_schema:
-            return False
-        if self.drop_query.template != other.drop_query.template:
             return False
         if self.create_query.template != other.create_query.template:
             return False
@@ -40,7 +37,6 @@ class UDFGenTableResult(UDFGenResult):
             f"UDFGenTableResult("
             f"{self.tablename_placeholder=}, "
             f"{self.table_schema=}, "
-            f"{self.drop_query.template=}, "
             f"{self.create_query.template=}"
             f")"
         )

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -874,13 +874,11 @@ def create_table_udf_output(
     output_type: OutputType,
     table_name: str,
 ) -> UDFGenResult:
-    drop_table = "DROP TABLE IF EXISTS" + " $" + table_name + ";"
     output_schema = iotype_to_sql_schema(output_type)
     create_table = "CREATE TABLE" + " $" + table_name + f"({output_schema})" + ";"
     return UDFGenTableResult(
         tablename_placeholder=table_name,
         table_schema=output_type.schema,
-        drop_query=Template(drop_table),
         create_query=Template(create_table),
     )
 

--- a/tasks.py
+++ b/tasks.py
@@ -330,9 +330,7 @@ def create_monetdb(
             f"Starting container {container_name} on ports {container_ports}...",
             Level.HEADER,
         )
-        hard_memory_limit = monetdb_memory_limit + 1024
-        soft_memory_limit = monetdb_memory_limit
-        cmd = f"""docker run -d -P -p {container_ports} -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={hard_memory_limit}m --memory-reservation={soft_memory_limit}m {image}"""
+        cmd = f"""docker run -d -P -p {container_ports} -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
         run(c, cmd)
 
 

--- a/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
@@ -16,14 +16,15 @@ expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected
     "test_input, expected",
     get_test_params(
         expected_file,
-        skip_indices=[3, 5, 12, 17, 18, 19],
+        skip_indices=[3, 5, 6, 12, 17, 18, 19],
         skip_reason="Tests 5, 9, 12, 18, 19, 22 results in empty tables, "
         "https://team-1617704806227.atlassian.net/browse/MIP-634.\n"
         "Test 17 fails to converge in CI, but succeeds when run locally"
         "https://team-1617704806227.atlassian.net/browse/MIP-680."
         "Test 5 seems to fail only on the one-node deployment(local & CI deployment)"
-        "Test 3 seems to fail only on CI (but succeeds when run locally) and only for "
-        "one-node deployment",
+        "Test 3, 6 seems to fail only on CI (but succeeds when run locally) and only for "
+        "one-node deployment,"
+        "https://team-1617704806227.atlassian.net/browse/MIP-733",
     ),
 )
 def test_logisticregression_cv_algorithm(test_input, expected, subtests):

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -22,6 +22,7 @@ from mipengine.controller.celery_app import CeleryAppFactory
 from mipengine.controller.controller_logger import init_logger
 from mipengine.controller.node_landscape_aggregator import NodeLandscapeAggregator
 from mipengine.controller.node_landscape_aggregator import _NLARegistries
+from mipengine.node.monetdb_interface.monet_db_facade import _MonetDBConnectionPool
 from mipengine.udfgen import udfio
 
 ALGORITHM_FOLDERS_ENV_VARIABLE_VALUE = "./mipengine/algorithms,./tests/algorithms"
@@ -519,6 +520,11 @@ def _clean_db(cursor):
                 cursor.execute(f"DROP VIEW {table_name}")
             else:
                 cursor.execute(f"DROP TABLE {table_name}")
+
+
+@pytest.fixture(scope="function")
+def reset_monet_db_facade_connection_pool():
+    _MonetDBConnectionPool()._connection_pool = []
 
 
 @pytest.fixture(scope="function")

--- a/tests/standalone_tests/test_monet_db_facade.py
+++ b/tests/standalone_tests/test_monet_db_facade.py
@@ -1,11 +1,9 @@
-from time import sleep
 from unittest.mock import patch
 
 import pymonetdb
 import pytest
 
 from mipengine import AttrDict
-from mipengine.node.monetdb_interface.monet_db_facade import _MonetDBConnectionPool
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
 from mipengine.node.node_logger import init_logger
 from tests.standalone_tests.conftest import COMMON_IP
@@ -13,11 +11,6 @@ from tests.standalone_tests.conftest import MONETDB_LOCALNODETMP_NAME
 from tests.standalone_tests.conftest import MONETDB_LOCALNODETMP_PORT
 from tests.standalone_tests.conftest import remove_monetdb_container
 from tests.standalone_tests.conftest import restart_monetdb_container
-
-
-@pytest.fixture(scope="function", autouse=True)
-def reset_monet_db_facade_connection_pool():
-    _MonetDBConnectionPool._connection_pool = []
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -71,6 +64,7 @@ def patch_node_config():
 @pytest.mark.very_slow
 def test_execute_and_fetchall_success(
     monetdb_localnodetmp,
+    reset_monet_db_facade_connection_pool,
 ):
     result = db_execute_and_fetchall(query="SELECT 1;")
     assert result[0][0] == 1
@@ -81,12 +75,13 @@ def test_execute_and_fetchall_success(
 def test_broken_pipe_error_properly_handled(
     capfd,
     monetdb_localnodetmp,
+    reset_monet_db_facade_connection_pool,
 ):
     result = db_execute_and_fetchall(query="SELECT 1;")
     assert result[0][0] == 1
     restart_monetdb_container(MONETDB_LOCALNODETMP_NAME)
     result = db_execute_and_fetchall(query="SELECT 1;")
-    out, err = capfd.readouterr()
+    _, err = capfd.readouterr()
     assert (
         "Trying to recover the connection with the database. Exception type: '<class 'BrokenPipeError'>'"
         in err
@@ -99,6 +94,7 @@ def test_broken_pipe_error_properly_handled(
 def test_connection_refused_properly_handled(
     capfd,
     monetdb_localnodetmp,
+    reset_monet_db_facade_connection_pool,
 ):
     remove_monetdb_container(MONETDB_LOCALNODETMP_NAME)
     with pytest.raises(ConnectionError):
@@ -112,12 +108,17 @@ def test_connection_refused_properly_handled(
 
 @pytest.mark.slow
 @pytest.mark.very_slow
-def test_generic_exception_handled(monetdb_localnodetmp):
+def test_generic_exception_handled(
+    monetdb_localnodetmp,
+    reset_monet_db_facade_connection_pool,
+):
     with pytest.raises(pymonetdb.exceptions.OperationalError):
         db_execute_and_fetchall(query="SELECT * FROM non_existing_table;")
 
 
-def test_connection_refused_with_stopped_monetdb_container():
+def test_connection_refused_with_stopped_monetdb_container(
+    reset_monet_db_facade_connection_pool,
+):
     with patch(
         "mipengine.node.monetdb_interface.monet_db_facade.CONN_RECOVERY_MAX_ATTEMPTS", 1
     ), pytest.raises(ConnectionError):

--- a/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
+++ b/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
@@ -168,7 +168,9 @@ def test_create_remote_table_if_not_exists(
 @pytest.mark.slow
 def test_create_merge_table_if_not_exists(
     use_localnode1_database,
+    create_sample_table,
 ):
+    sample_table_info = create_sample_table
     table_name = "test_create_merge_table_if_not_exists"
     table_schema = TableSchema(
         columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
@@ -176,12 +178,14 @@ def test_create_merge_table_if_not_exists(
     create_merge_table(
         table_name=table_name,
         table_schema=table_schema,
+        merge_table_names=[sample_table_info.name],
     )
 
     try:
         create_merge_table(
             table_name=table_name,
             table_schema=table_schema,
+            merge_table_names=[sample_table_info.name],
         )
     except Exception as exc:
         pytest.fail(
@@ -215,10 +219,10 @@ def test_create_merge_table_if_not_exists_query():
     with patch(
         "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
     ) as execute_and_commit_mock:
-        _execute("CREATE MERGE TABLE")
+        _execute("CREATE MERGE TABLE sample_table")
         assert (
             execute_and_commit_mock.call_args.args[1].query
-            == "CREATE MERGE TABLE IF NOT EXISTS"
+            == "DROP TABLE IF EXISTS sample_table; CREATE MERGE TABLE sample_table"
         )
 
 

--- a/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
+++ b/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
@@ -1,0 +1,258 @@
+from unittest.mock import patch
+
+import pytest
+
+from mipengine import AttrDict
+from mipengine import DType
+from mipengine.node.monetdb_interface.merge_tables import create_merge_table
+from mipengine.node.monetdb_interface.monet_db_facade import _execute
+from mipengine.node.monetdb_interface.remote_tables import create_remote_table
+from mipengine.node.monetdb_interface.tables import create_table
+from mipengine.node.monetdb_interface.views import create_view
+from mipengine.node.node_logger import init_logger
+from mipengine.node_tasks_DTOs import ColumnInfo
+from mipengine.node_tasks_DTOs import TableInfo
+from mipengine.node_tasks_DTOs import TableSchema
+from mipengine.node_tasks_DTOs import TableType
+from tests.standalone_tests.conftest import COMMON_IP
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_node_logger():
+    current_task = AttrDict({"request": {"id": "1234"}})
+
+    with patch(
+        "mipengine.node.node_logger.node_config",
+        AttrDict(
+            {
+                "log_level": "DEBUG",
+                "role": "localnode",
+                "identifier": "localnodetmp",
+            },
+        ),
+    ), patch(
+        "mipengine.node.node_logger.task_loggers",
+        {"1234": init_logger("1234")},
+    ), patch(
+        "mipengine.node.node_logger.current_task",
+        current_task,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_node_config():
+    node_config = AttrDict(
+        {
+            "monetdb": {
+                "ip": COMMON_IP,
+                "port": MONETDB_LOCALNODE1_PORT,
+                "database": "db",
+                "username": "monetdb",
+                "password": "monetdb",
+            },
+            "celery": {
+                "tasks_timeout": 60,
+                "run_udf_task_timeout": 120,
+                "worker_concurrency": 1,
+            },
+        }
+    )
+
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade.node_config", node_config
+    ):
+        yield
+
+
+@pytest.fixture(scope="function")
+def create_sample_table(
+    use_localnode1_database,
+    localnode1_db_cursor,
+) -> TableInfo:
+    info = TableInfo(
+        name="table_test_tables_if_not_exists",
+        schema_=TableSchema(
+            columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
+        ),
+        type_=TableType.NORMAL,
+    )
+    localnode1_db_cursor.execute(
+        f"CREATE TABLE {info.name} ( {info.column_names[0]} {info.schema_.columns[0].dtype.value})"
+    )
+    localnode1_db_cursor.execute(
+        f"INSERT INTO {info.name} ( {info.column_names[0]} ) VALUES ( 10 )"
+    )
+    return info
+
+
+@pytest.mark.slow
+def test_create_view_if_not_exists(
+    use_localnode1_database,
+    create_sample_table,
+):
+    table_info = create_sample_table
+    view_name = "view_test_create_view_if_not_exists"
+
+    create_view(
+        view_name=view_name,
+        table_name=table_info.name,
+        columns=table_info.column_names,
+        filters=None,
+        minimum_row_count=0,
+        check_min_rows=False,
+    )
+
+    try:
+        create_view(
+            view_name=view_name,
+            table_name=table_info.name,
+            columns=table_info.column_names,
+            filters=None,
+            minimum_row_count=0,
+            check_min_rows=False,
+        )
+    except Exception as exc:
+        pytest.fail(f"A view should be able to be recreated. Exception: \n{str(exc)} ")
+
+
+@pytest.mark.slow
+def test_create_table_if_not_exists(
+    use_localnode1_database,
+):
+    table_name = "test_create_table_if_not_exists"
+    table_schema = TableSchema(
+        columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
+    )
+    create_table(
+        table_name=table_name,
+        table_schema=table_schema,
+    )
+
+    try:
+        create_table(
+            table_name=table_name,
+            table_schema=table_schema,
+        )
+    except Exception as exc:
+        pytest.fail(f"A table should be able to be recreated. Exception: \n{str(exc)} ")
+
+
+@pytest.mark.slow
+def test_create_remote_table_if_not_exists(
+    use_localnode1_database,
+):
+    table_name = "test_create_remote_table_if_not_exists"
+    table_schema = TableSchema(
+        columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
+    )
+    create_remote_table(
+        name=table_name,
+        monetdb_socket_address="127.0.0.1:50000",
+        schema=table_schema,
+    )
+
+    try:
+        create_remote_table(
+            name=table_name,
+            monetdb_socket_address="127.0.0.1:50000",
+            schema=table_schema,
+        )
+    except Exception as exc:
+        pytest.fail(
+            f"A remote table should be able to be recreated. Exception: \n{str(exc)} "
+        )
+
+
+@pytest.mark.slow
+def test_create_merge_table_if_not_exists(
+    use_localnode1_database,
+):
+    table_name = "test_create_merge_table_if_not_exists"
+    table_schema = TableSchema(
+        columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
+    )
+    create_merge_table(
+        table_name=table_name,
+        table_schema=table_schema,
+    )
+
+    try:
+        create_merge_table(
+            table_name=table_name,
+            table_schema=table_schema,
+        )
+    except Exception as exc:
+        pytest.fail(
+            f"A merge table should be able to be recreated. Exception: \n{str(exc)} "
+        )
+
+
+def test_create_table_if_not_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("CREATE TABLE")
+        assert (
+            execute_and_commit_mock.call_args.args[1].query
+            == "CREATE TABLE IF NOT EXISTS"
+        )
+
+
+def test_create_remote_table_if_not_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("CREATE REMOTE TABLE")
+        assert (
+            execute_and_commit_mock.call_args.args[1].query
+            == "CREATE REMOTE TABLE IF NOT EXISTS"
+        )
+
+
+def test_create_merge_table_if_not_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("CREATE MERGE TABLE")
+        assert (
+            execute_and_commit_mock.call_args.args[1].query
+            == "CREATE MERGE TABLE IF NOT EXISTS"
+        )
+
+
+def test_create_view_if_not_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("CREATE VIEW")
+        assert (
+            execute_and_commit_mock.call_args.args[1].query == "CREATE OR REPLACE VIEW"
+        )
+
+
+def test_drop_view_if_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("DROP VIEW")
+        assert execute_and_commit_mock.call_args.args[1].query == "DROP VIEW IF EXISTS"
+
+
+def test_drop_table_if_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("DROP TABLE")
+        assert execute_and_commit_mock.call_args.args[1].query == "DROP TABLE IF EXISTS"
+
+
+def test_drop_function_if_exists_query():
+    with patch(
+        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
+    ) as execute_and_commit_mock:
+        _execute("DROP FUNCTION")
+        assert (
+            execute_and_commit_mock.call_args.args[1].query == "DROP FUNCTION IF EXISTS"
+        )

--- a/tests/standalone_tests/udfgen/test_tensor_ops.py
+++ b/tests/standalone_tests/udfgen/test_tensor_ops.py
@@ -77,7 +77,6 @@ ORDER BY
                     ("dim0", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" DOUBLE);'
                 ),
@@ -169,7 +168,6 @@ ORDER BY
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -239,7 +237,6 @@ FROM
                     ("dim0", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" DOUBLE);'
                 ),

--- a/tests/standalone_tests/udfgen/test_udfgenerator.py
+++ b/tests/standalone_tests/udfgen/test_udfgenerator.py
@@ -305,7 +305,6 @@ class TestUDFGenBase:
     def _concrete_table_udf_outputs(output: UDFGenTableResult):
         queries = []
         template_mapping = {output.tablename_placeholder: output.tablename_placeholder}
-        queries.append(output.drop_query.substitute(**template_mapping))
         queries.append(output.create_query.substitute(**template_mapping))
         return queries
 
@@ -842,7 +841,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -942,7 +940,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -1067,7 +1064,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -1193,7 +1189,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -1339,7 +1334,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -1464,7 +1458,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -1564,7 +1557,6 @@ FROM
                     ("ci", DType.INT),
                     ("cf", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("ci" INT,"cf" DOUBLE);'
                 ),
@@ -1665,7 +1657,6 @@ FROM
                 table_schema=[
                     ("result", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("result" INT);'
                 ),
@@ -1769,7 +1760,6 @@ FROM
                 table_schema=[
                     ("result", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("result" INT);'
                 ),
@@ -1848,7 +1838,6 @@ FROM
                     ("dim0", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" INT);'
                 ),
@@ -1950,7 +1939,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -2052,7 +2040,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" DOUBLE);'
                 ),
@@ -2154,7 +2141,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" INT);'
                 ),
@@ -2271,7 +2257,6 @@ FROM
                     ("dim0", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" INT);'
                 ),
@@ -2405,7 +2390,6 @@ FROM
                     ("dim0", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" INT);'
                 ),
@@ -2548,7 +2532,6 @@ FROM
                     ("dim1", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"dim1" INT,"val" INT);'
                 ),
@@ -2647,7 +2630,6 @@ FROM
                     ("dim0", DType.INT),
                     ("val", DType.INT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("dim0" INT,"val" INT);'
                 ),
@@ -2725,7 +2707,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -2839,7 +2820,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -2936,7 +2916,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -3050,7 +3029,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -3165,7 +3143,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -3294,7 +3271,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -3430,7 +3406,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -3561,7 +3536,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -3571,7 +3545,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $loopback_table_name_0;"),
                 create_query=Template(
                     'CREATE TABLE $loopback_table_name_0("transfer" CLOB);'
                 ),
@@ -3707,7 +3680,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -3717,7 +3689,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $loopback_table_name_0;"),
                 create_query=Template(
                     'CREATE TABLE $loopback_table_name_0("state" BLOB);'
                 ),
@@ -3859,7 +3830,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -3869,7 +3839,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $loopback_table_name_0;"),
                 create_query=Template(
                     'CREATE TABLE $loopback_table_name_0("transfer" CLOB);'
                 ),
@@ -3996,7 +3965,6 @@ FROM
                 table_schema=[
                     ("secure_transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("secure_transfer" CLOB);'
                 ),
@@ -4123,9 +4091,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $main_output_table_name;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $main_output_table_name("secure_transfer" CLOB);'
                     ),
@@ -4135,9 +4100,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $main_output_table_name_sum_op;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $main_output_table_name_sum_op("secure_transfer" CLOB);'
                     ),
@@ -4147,9 +4109,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $main_output_table_name_max_op;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $main_output_table_name_max_op("secure_transfer" CLOB);'
                     ),
@@ -4291,7 +4250,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -4301,7 +4259,6 @@ FROM
                 table_schema=[
                     ("secure_transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $loopback_table_name_0;"),
                 create_query=Template(
                     'CREATE TABLE $loopback_table_name_0("secure_transfer" CLOB);'
                 ),
@@ -4435,7 +4392,6 @@ FROM
                 table_schema=[
                     ("state", DType.BINARY),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("state" BLOB);'
                 ),
@@ -4446,7 +4402,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template("DROP TABLE IF EXISTS $loopback_table_name_0;"),
                     create_query=Template(
                         'CREATE TABLE $loopback_table_name_0("secure_transfer" CLOB);'
                     ),
@@ -4456,9 +4411,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $loopback_table_name_0_sum_op;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $loopback_table_name_0_sum_op("secure_transfer" CLOB);'
                     ),
@@ -4468,9 +4420,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $loopback_table_name_0_min_op;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $loopback_table_name_0_min_op("secure_transfer" CLOB);'
                     ),
@@ -4480,9 +4429,6 @@ FROM
                     table_schema=[
                         ("secure_transfer", DType.JSON),
                     ],
-                    drop_query=Template(
-                        "DROP TABLE IF EXISTS $loopback_table_name_0_max_op;"
-                    ),
                     create_query=Template(
                         'CREATE TABLE $loopback_table_name_0_max_op("secure_transfer" CLOB);'
                     ),
@@ -4618,7 +4564,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -4756,7 +4701,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -4865,7 +4809,6 @@ FROM
                 table_schema=[
                     ("transfer", DType.JSON),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("transfer" CLOB);'
                 ),
@@ -4957,7 +4900,6 @@ FROM
                     ("a", DType.INT),
                     ("b", DType.FLOAT),
                 ],
-                drop_query=Template("DROP TABLE IF EXISTS $main_output_table_name;"),
                 create_query=Template(
                     'CREATE TABLE $main_output_table_name("a" INT,"b" DOUBLE);'
                 ),


### PR DESCRIPTION
Changelog:
  - Removed drop table query from the udf execution queries.
  - Added fault tolerance logic on the queries to avoid incorrect state when creating tables due to "Server closed the connection" errors.
  - Integration tests added for the monetdb_interface, with the monetdb below, without passing through the celery tasks.