### PR TITLE
Dev/mip 758/enhanced enum types in algo specs

### DIFF
--- a/mipengine/algorithms/anova.json
+++ b/mipengine/algorithms/anova.json
@@ -35,7 +35,7 @@
         "sstype": {
             "label": "sstype",
             "desc": "Type of sum of squares to use. It can be 1 or 2.",
-            "type": "int",
+            "types": ["int"],
             "default": "2",
             "min": 1,
             "max": 2,

--- a/mipengine/algorithms/anova_oneway.json
+++ b/mipengine/algorithms/anova_oneway.json
@@ -30,8 +30,5 @@
         }
     },
     "parameters": {
-    },
-    "flags": {
-        "formula": false
     }
 }

--- a/mipengine/algorithms/linear_regression_cv.json
+++ b/mipengine/algorithms/linear_regression_cv.json
@@ -36,7 +36,7 @@
         "n_splits": {
             "label": "Number of splits",
             "desc": "Number of splits",
-            "type": "int",
+            "types": ["int"],
             "min": 2,
             "max": 20,
             "default": 5,

--- a/mipengine/algorithms/logistic_regression.json
+++ b/mipengine/algorithms/logistic_regression.json
@@ -35,7 +35,7 @@
             "desc": "Positive class of y. All other classes are considered negative.",
             "types": ["text", "int"],
             "enums": {
-                "type": "inputdata_CDE_enums",
+                "type": "input_var_CDE_enums",
                 "source": "y"
             },
             "default": null,

--- a/mipengine/algorithms/logistic_regression.json
+++ b/mipengine/algorithms/logistic_regression.json
@@ -34,7 +34,10 @@
             "label": "Positive class",
             "desc": "Positive class of y. All other classes are considered negative.",
             "types": ["text", "int"],
-            "variable_group": "y",
+            "enums": {
+                "type": "inputdata_CDE_enums",
+                "source": "y"
+            },
             "default": null,
             "notblank": true,
             "multiple": false

--- a/mipengine/algorithms/logistic_regression.json
+++ b/mipengine/algorithms/logistic_regression.json
@@ -33,7 +33,7 @@
         "positive_class" : {
             "label": "Positive class",
             "desc": "Positive class of y. All other classes are considered negative.",
-            "type": "enum_from_cde",
+            "types": ["text", "int"],
             "variable_group": "y",
             "default": null,
             "notblank": true,

--- a/mipengine/algorithms/logistic_regression_cv.json
+++ b/mipengine/algorithms/logistic_regression_cv.json
@@ -33,7 +33,7 @@
         "positive_class" : {
             "label": "Positive class",
             "desc": "Positive class of y. All other classes are considered negative.",
-            "type": "enum_from_cde",
+            "types": ["text", "int"],
             "variable_group": "y",
             "default": null,
             "notblank": true,
@@ -42,7 +42,7 @@
         "n_splits": {
             "label": "Number of splits",
             "desc": "Number of splits",
-            "type": "int",
+            "types": ["int"],
             "min": 2,
             "max": 20,
             "default": 5,

--- a/mipengine/algorithms/logistic_regression_cv.json
+++ b/mipengine/algorithms/logistic_regression_cv.json
@@ -33,8 +33,11 @@
         "positive_class" : {
             "label": "Positive class",
             "desc": "Positive class of y. All other classes are considered negative.",
-            "types": ["text", "int"],
-            "variable_group": "y",
+            "types": ["int", "text"],
+            "enums": {
+                "type": "inputdata_CDE_enums",
+                "source": "y"
+            },
             "default": null,
             "notblank": true,
             "multiple": false

--- a/mipengine/algorithms/logistic_regression_cv.json
+++ b/mipengine/algorithms/logistic_regression_cv.json
@@ -35,7 +35,7 @@
             "desc": "Positive class of y. All other classes are considered negative.",
             "types": ["int", "text"],
             "enums": {
-                "type": "inputdata_CDE_enums",
+                "type": "input_var_CDE_enums",
                 "source": "y"
             },
             "default": null,

--- a/mipengine/algorithms/multiple_histograms.json
+++ b/mipengine/algorithms/multiple_histograms.json
@@ -24,7 +24,7 @@
     "parameters":{
         "bins": {
             "label": "Number of bins",
-            "type": "int",
+            "types": ["int"],
             "desc" :"Number of bins",
             "min": 1,
             "max": 100,

--- a/mipengine/algorithms/pca.json
+++ b/mipengine/algorithms/pca.json
@@ -18,8 +18,5 @@
         }
     },
     "parameters": {
-    },
-    "flags": {
-        "formula": false
     }
 }

--- a/mipengine/algorithms/pearson_correlation.json
+++ b/mipengine/algorithms/pearson_correlation.json
@@ -25,7 +25,7 @@
         "alpha": {
             "label": "Confidence level",
             "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-            "type": "real",
+            "types": ["real"],
             "default": 0.95,
             "min": 0.0,
             "max": 1.0,

--- a/mipengine/algorithms/ttest_independent.json
+++ b/mipengine/algorithms/ttest_independent.json
@@ -36,7 +36,7 @@
             "types": ["text"],
             "default": "two-sided",
             "enums": {
-                "type": "enums_from_list",
+                "type": "list",
                 "source": [
                     "two-sided",
                     "less",

--- a/mipengine/algorithms/ttest_independent.json
+++ b/mipengine/algorithms/ttest_independent.json
@@ -33,7 +33,7 @@
         "alt_hypothesis": {
             "label": "Alternative Hypothesis",
             "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
-            "type": "text",
+            "types": ["text"],
             "default": "two-sided",
             "enums": {
                 "type": "enums_from_list",
@@ -49,15 +49,12 @@
         "confidence_lvl": {
             "label": "Confidence level",
             "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-            "type": "real",
+            "types": ["real"],
             "default": 0.95,
             "min": 0.0,
             "max": 1.0,
             "notblank": true,
             "multiple": false
         }
-    },
-    "flags": {
-        "formula": false
     }
 }

--- a/mipengine/algorithms/ttest_independent.json
+++ b/mipengine/algorithms/ttest_independent.json
@@ -35,7 +35,14 @@
             "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
             "type": "text",
             "default": "two-sided",
-            "enums": ["two-sided", "less", "greater"],
+            "enums": {
+                "type": "enums_from_list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            },
             "notblank": true,
             "multiple": false
         },

--- a/mipengine/algorithms/ttest_onesample.json
+++ b/mipengine/algorithms/ttest_onesample.json
@@ -24,7 +24,7 @@
             "types": ["text"],
             "default": "two-sided",
             "enums": {
-                "type": "enums_from_list",
+                "type": "list",
                 "source": [
                     "two-sided",
                     "less",

--- a/mipengine/algorithms/ttest_onesample.json
+++ b/mipengine/algorithms/ttest_onesample.json
@@ -23,7 +23,14 @@
             "desc": "The alternative hypothesis to the null, returning specifically whether the result is less than, greater than, or .",
             "type": "text",
             "default": "two-sided",
-            "enums": ["two-sided", "less", "greater"],
+            "enums": {
+                "type": "enums_from_list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            },
             "notblank": true,
             "multiple": false
         },

--- a/mipengine/algorithms/ttest_onesample.json
+++ b/mipengine/algorithms/ttest_onesample.json
@@ -21,7 +21,7 @@
         "alt_hypothesis": {
             "label": "Alternative Hypothesis",
             "desc": "The alternative hypothesis to the null, returning specifically whether the result is less than, greater than, or .",
-            "type": "text",
+            "types": ["text"],
             "default": "two-sided",
             "enums": {
                 "type": "enums_from_list",
@@ -37,7 +37,7 @@
         "alpha": {
             "label": "Confidence level",
             "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-            "type": "real",
+            "types": ["real"],
             "default": 0.95,
             "min": 0.0,
             "max": 1.0,
@@ -47,15 +47,12 @@
         "mu": {
             "label": "Population mean",
             "desc": "The population mean, if it is known, else it defaults to 0.",
-            "type": "real",
+            "types": ["real"],
             "default": 0.0,
             "min": -10,
             "max": 10,
             "notblank": true,
             "multiple": false
         }
-    },
-    "flags": {
-        "formula": false
     }
 }

--- a/mipengine/algorithms/ttest_paired.json
+++ b/mipengine/algorithms/ttest_paired.json
@@ -33,7 +33,7 @@
         "alt_hypothesis": {
             "label": "Alternative Hypothesis",
             "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
-            "type": "text",
+            "types": ["text"],
             "default": "two-sided",
             "enums": {
                 "type": "enums_from_list",
@@ -49,15 +49,12 @@
         "alpha": {
             "label": "Confidence level",
             "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-            "type": "real",
+            "types": ["real"],
             "default": 0.95,
             "min": 0.0,
             "max": 1.0,
             "notblank": true,
             "multiple": false
         }
-    },
-    "flags": {
-        "formula": false
     }
 }

--- a/mipengine/algorithms/ttest_paired.json
+++ b/mipengine/algorithms/ttest_paired.json
@@ -36,7 +36,7 @@
             "types": ["text"],
             "default": "two-sided",
             "enums": {
-                "type": "enums_from_list",
+                "type": "list",
                 "source": [
                     "two-sided",
                     "less",

--- a/mipengine/algorithms/ttest_paired.json
+++ b/mipengine/algorithms/ttest_paired.json
@@ -35,7 +35,14 @@
             "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
             "type": "text",
             "default": "two-sided",
-            "enums": ["two-sided", "less", "greater"],
+            "enums": {
+                "type": "enums_from_list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            },
             "notblank": true,
             "multiple": false
         },

--- a/mipengine/controller/algorithm_specifications.py
+++ b/mipengine/controller/algorithm_specifications.py
@@ -150,15 +150,15 @@ class ParameterSpecification(BaseModel):
         )
 
 
-def _validate_parameter_with_enums_type_inputdata_CDE_enums(param_value, cls_values):
+def _validate_parameter_with_enums_type_input_var_CDE_enums(param_value, cls_values):
     if param_value.enums.source not in ["x", "y"]:
         raise ValueError(
-            f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type 'inputdata_CDE_enums' "
+            f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type 'input_var_CDE_enums' "
             f"that supports only 'x' or 'y' as source. Value given: '{param_value.enums.source}'."
         )
     if param_value.multiple:
         raise ValueError(
-            f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type 'inputdata_CDE_enums' "
+            f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type 'input_var_CDE_enums' "
             f"that doesn't support 'multiple=True', in the parameter."
         )
     inputdata_var = (
@@ -169,16 +169,16 @@ def _validate_parameter_with_enums_type_inputdata_CDE_enums(param_value, cls_val
     if inputdata_var.multiple:
         raise ValueError(
             f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type "
-            f"'{ParameterEnumType.INPUTDATA_CDE_ENUMS.value}' "
+            f"'{ParameterEnumType.INPUT_VAR_CDE_ENUMS.value}' "
             f"that doesn't support 'multiple=True' in it's linked inputdata var '{inputdata_var.label}'."
         )
 
 
-def _validate_parameter_with_enums_type_inputdata_CDEs(param_value, cls_values):
+def _validate_parameter_with_enums_type_input_var_names(param_value, cls_values):
     if param_value.types != [ParameterType.TEXT]:
         raise ValueError(
             f"In algorithm '{cls_values['label']}', parameter '{param_value.label}' has enums type "
-            f"'{ParameterEnumType.INPUTDATA_CDES.value}' that supports ONLY 'types=[\"text\"]' but the 'types' "
+            f"'{ParameterEnumType.INPUT_VAR_NAMES.value}' that supports ONLY 'types=[\"text\"]' but the 'types' "
             f"provided were {[t.value for t in param_value.types]}."
         )
 
@@ -200,12 +200,12 @@ class AlgorithmSpecification(BaseModel):
         for param_value in cls_values["parameters"].values():
             if not param_value.enums:
                 continue
-            if param_value.enums.type == ParameterEnumType.INPUTDATA_CDE_ENUMS:
-                _validate_parameter_with_enums_type_inputdata_CDE_enums(
+            if param_value.enums.type == ParameterEnumType.INPUT_VAR_CDE_ENUMS:
+                _validate_parameter_with_enums_type_input_var_CDE_enums(
                     param_value, cls_values
                 )
-            if param_value.enums.type == ParameterEnumType.INPUTDATA_CDES:
-                _validate_parameter_with_enums_type_inputdata_CDEs(
+            if param_value.enums.type == ParameterEnumType.INPUT_VAR_NAMES:
+                _validate_parameter_with_enums_type_input_var_names(
                     param_value, cls_values
                 )
         return cls_values

--- a/mipengine/controller/algorithm_specifications.py
+++ b/mipengine/controller/algorithm_specifications.py
@@ -123,7 +123,7 @@ class ParameterEnumSpecification(BaseModel):
 class ParameterSpecification(BaseModel):
     label: str
     desc: str
-    type: ParameterType
+    types: List[ParameterType]
     notblank: bool
     multiple: bool
     default: Any
@@ -135,7 +135,7 @@ class ParameterSpecification(BaseModel):
         return ParameterSpecificationDTO(
             label=self.label,
             desc=self.desc,
-            type=self.type,
+            types=self.types,
             notblank=self.notblank,
             multiple=self.multiple,
             default=self.default,

--- a/mipengine/controller/algorithm_specifications.py
+++ b/mipengine/controller/algorithm_specifications.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -24,6 +25,7 @@ from mipengine.controller.api.algorithm_specifications_dtos import InputDataType
 from mipengine.controller.api.algorithm_specifications_dtos import (
     ParameterSpecificationDTO,
 )
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterType
 
 
 class InputDataSpecification(BaseModel):
@@ -103,9 +105,28 @@ class InputDataSpecifications(BaseModel):
         )
 
 
-class ParameterSpecification(ParameterSpecificationDTO):
-    # The parameter specification is identical to the DTO
-    pass
+class ParameterSpecification(BaseModel):
+    label: str
+    desc: str
+    type: ParameterType
+    notblank: bool
+    multiple: bool
+    default: Any
+    enums: Optional[List[Any]]
+    min: Optional[float]
+    max: Optional[float]
+
+    def convert_to_parameter_specification_dto(self):
+        return ParameterSpecificationDTO(
+            label=self.label,
+            type=self.type,
+            notblank=self.notblank,
+            multiple=self.multiple,
+            default=self.default,
+            enums=self.enums,
+            min=self.min,
+            max=self.max,
+        )
 
 
 class AlgorithmSpecification(BaseModel):
@@ -124,7 +145,10 @@ class AlgorithmSpecification(BaseModel):
             desc=self.desc,
             label=self.label,
             inputdata=self.inputdata.convert_to_inputdata_specifications_dto(),
-            parameters=self.parameters,
+            parameters=[
+                parameter.convert_to_parameter_specification_dto()
+                for parameter in self.parameters
+            ],
         )
 
 

--- a/mipengine/controller/algorithm_specifications.py
+++ b/mipengine/controller/algorithm_specifications.py
@@ -23,6 +23,10 @@ from mipengine.controller.api.algorithm_specifications_dtos import (
 from mipengine.controller.api.algorithm_specifications_dtos import InputDataStatType
 from mipengine.controller.api.algorithm_specifications_dtos import InputDataType
 from mipengine.controller.api.algorithm_specifications_dtos import (
+    ParameterEnumSpecificationDTO,
+)
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
+from mipengine.controller.api.algorithm_specifications_dtos import (
     ParameterSpecificationDTO,
 )
 from mipengine.controller.api.algorithm_specifications_dtos import ParameterType
@@ -105,6 +109,17 @@ class InputDataSpecifications(BaseModel):
         )
 
 
+class ParameterEnumSpecification(BaseModel):
+    type: ParameterEnumType
+    source: Any
+
+    def convert_to_parameter_enum_specification_dto(self):
+        return ParameterEnumSpecificationDTO(
+            type=self.type,
+            source=self.source,
+        )
+
+
 class ParameterSpecification(BaseModel):
     label: str
     desc: str
@@ -112,18 +127,21 @@ class ParameterSpecification(BaseModel):
     notblank: bool
     multiple: bool
     default: Any
-    enums: Optional[List[Any]]
+    enums: Optional[ParameterEnumSpecification]
     min: Optional[float]
     max: Optional[float]
 
     def convert_to_parameter_specification_dto(self):
         return ParameterSpecificationDTO(
             label=self.label,
+            desc=self.desc,
             type=self.type,
             notblank=self.notblank,
             multiple=self.multiple,
             default=self.default,
-            enums=self.enums,
+            enums=self.enums.convert_to_parameter_enum_specification_dto()
+            if self.enums
+            else None,
             min=self.min,
             max=self.max,
         )
@@ -145,10 +163,12 @@ class AlgorithmSpecification(BaseModel):
             desc=self.desc,
             label=self.label,
             inputdata=self.inputdata.convert_to_inputdata_specifications_dto(),
-            parameters=[
-                parameter.convert_to_parameter_specification_dto()
-                for parameter in self.parameters
-            ],
+            parameters={
+                name: value.convert_to_parameter_specification_dto()
+                for name, value in self.parameters.items()
+            }
+            if self.parameters
+            else None,
         )
 
 

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -39,9 +39,9 @@ class ParameterType(str, Enum):
 @unique
 class ParameterEnumType(str, Enum):
     LIST = "list"
-    INPUTDATA_CDE_ENUMS = "inputdata_CDE_enums"
-    CDE_ENUMS = "CDE_enums"
-    INPUTDATA_CDES = "inputdata_CDEs"
+    INPUT_VAR_CDE_ENUMS = "input_var_CDE_enums"
+    FIXED_VAR_CDE_ENUMS = "fixed_var_CDE_enums"
+    INPUT_VAR_NAMES = "input_var_names"
 
 
 class InputDataSpecificationDTO(ImmutableBaseModel):

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -40,6 +40,7 @@ class ParameterType(str, Enum):
 class ParameterEnumType(str, Enum):
     LIST = "list"
     INPUTDATA_CDE_ENUMS = "inputdata_CDE_enums"
+    CDE_ENUMS = "CDE_enums"
 
 
 class InputDataSpecificationDTO(ImmutableBaseModel):

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -38,7 +38,8 @@ class ParameterType(str, Enum):
 
 @unique
 class ParameterEnumType(str, Enum):
-    ENUMS_FROM_LIST = "enums_from_list"
+    LIST = "list"
+    INPUTDATA_CDE_ENUMS = "inputdata_CDE_enums"
 
 
 class InputDataSpecificationDTO(ImmutableBaseModel):

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -41,6 +41,7 @@ class ParameterEnumType(str, Enum):
     LIST = "list"
     INPUTDATA_CDE_ENUMS = "inputdata_CDE_enums"
     CDE_ENUMS = "CDE_enums"
+    INPUTDATA_CDES = "inputdata_CDEs"
 
 
 class InputDataSpecificationDTO(ImmutableBaseModel):

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -34,7 +34,6 @@ class ParameterType(str, Enum):
     INT = "int"
     TEXT = "text"
     BOOLEAN = "boolean"
-    ENUM_FROM_CDE = "enum_from_cde"
 
 
 @unique
@@ -68,7 +67,7 @@ class ParameterEnumSpecificationDTO(ImmutableBaseModel):
 class ParameterSpecificationDTO(ImmutableBaseModel):
     label: str
     desc: str
-    type: ParameterType
+    types: List[ParameterType]
     notblank: bool
     multiple: bool
     default: Any

--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -34,8 +34,12 @@ class ParameterType(str, Enum):
     INT = "int"
     TEXT = "text"
     BOOLEAN = "boolean"
-    ENUM_FROM_LIST = "enum_from_list"
     ENUM_FROM_CDE = "enum_from_cde"
+
+
+@unique
+class ParameterEnumType(str, Enum):
+    ENUMS_FROM_LIST = "enums_from_list"
 
 
 class InputDataSpecificationDTO(ImmutableBaseModel):
@@ -56,6 +60,11 @@ class InputDataSpecificationsDTO(ImmutableBaseModel):
     x: Optional[InputDataSpecificationDTO]
 
 
+class ParameterEnumSpecificationDTO(ImmutableBaseModel):
+    type: ParameterEnumType
+    source: Any
+
+
 class ParameterSpecificationDTO(ImmutableBaseModel):
     label: str
     desc: str
@@ -63,7 +72,7 @@ class ParameterSpecificationDTO(ImmutableBaseModel):
     notblank: bool
     multiple: bool
     default: Any
-    enums: Optional[List[Any]]
+    enums: Optional[ParameterEnumSpecificationDTO]
     min: Optional[float]
     max: Optional[float]
 

--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -343,9 +343,28 @@ def _validate_param_enums(
         _validate_param_enums_of_type_CDE_enums(
             parameter_value, parameter_spec, data_model_cdes
         )
+    elif parameter_spec.enums.type == ParameterEnumType.INPUTDATA_CDES:
+        _validate_param_enums_of_type_inputdata_CDEs(
+            parameter_value, parameter_spec, inputdata
+        )
     else:
         raise NotImplementedError(
             f"Parameter enum type not supported: '{parameter_spec.enums.type}'."
+        )
+
+
+def _validate_param_enums_of_type_inputdata_CDEs(
+    parameter_value: Any,
+    parameter_spec: ParameterSpecification,
+    inputdata: AlgorithmInputDataDTO,
+):
+    inputdata_CDEs_enums = []
+    inputdata_CDEs_enums.extend(inputdata.y) if inputdata.y else None
+    inputdata_CDEs_enums.extend(inputdata.x) if inputdata.x else None
+    if parameter_value not in inputdata_CDEs_enums:
+        raise BadUserInput(
+            f"Parameter's '{parameter_spec.label}' enums, that are taken from inputdata {parameter_spec.enums.source} CDEs, "
+            f"should be one of the following: '{inputdata_CDEs_enums}'.",
         )
 
 

--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -335,16 +335,16 @@ def _validate_param_enums(
 
     if parameter_spec.enums.type == ParameterEnumType.LIST:
         _validate_param_enums_of_type_list(parameter_value, parameter_spec)
-    elif parameter_spec.enums.type == ParameterEnumType.INPUTDATA_CDE_ENUMS:
-        _validate_param_enums_of_type_inputdata_CDE_enums(
+    elif parameter_spec.enums.type == ParameterEnumType.INPUT_VAR_CDE_ENUMS:
+        _validate_param_enums_of_type_input_var_CDE_enums(
             parameter_value, parameter_spec, inputdata, data_model_cdes
         )
-    elif parameter_spec.enums.type == ParameterEnumType.CDE_ENUMS:
-        _validate_param_enums_of_type_CDE_enums(
+    elif parameter_spec.enums.type == ParameterEnumType.FIXED_VAR_CDE_ENUMS:
+        _validate_param_enums_of_type_fixed_var_CDE_enums(
             parameter_value, parameter_spec, data_model_cdes
         )
-    elif parameter_spec.enums.type == ParameterEnumType.INPUTDATA_CDES:
-        _validate_param_enums_of_type_inputdata_CDEs(
+    elif parameter_spec.enums.type == ParameterEnumType.INPUT_VAR_NAMES:
+        _validate_param_enums_of_type_input_var_names(
             parameter_value, parameter_spec, inputdata
         )
     else:
@@ -353,22 +353,22 @@ def _validate_param_enums(
         )
 
 
-def _validate_param_enums_of_type_inputdata_CDEs(
+def _validate_param_enums_of_type_input_var_names(
     parameter_value: Any,
     parameter_spec: ParameterSpecification,
     inputdata: AlgorithmInputDataDTO,
 ):
-    inputdata_CDEs_enums = []
-    inputdata_CDEs_enums.extend(inputdata.y) if inputdata.y else None
-    inputdata_CDEs_enums.extend(inputdata.x) if inputdata.x else None
-    if parameter_value not in inputdata_CDEs_enums:
+    input_var_names_enums = []
+    input_var_names_enums.extend(inputdata.y) if inputdata.y else None
+    input_var_names_enums.extend(inputdata.x) if inputdata.x else None
+    if parameter_value not in input_var_names_enums:
         raise BadUserInput(
-            f"Parameter's '{parameter_spec.label}' enums, that are taken from inputdata {parameter_spec.enums.source} CDEs, "
-            f"should be one of the following: '{inputdata_CDEs_enums}'.",
+            f"Parameter's '{parameter_spec.label}' enums, that are taken from inputdata {parameter_spec.enums.source} var names, "
+            f"should be one of the following: '{input_var_names_enums}'.",
         )
 
 
-def _validate_param_enums_of_type_CDE_enums(
+def _validate_param_enums_of_type_fixed_var_CDE_enums(
     parameter_value: Any,
     parameter_spec: ParameterSpecification,
     data_model_cdes: Dict[str, CommonDataElement],
@@ -378,33 +378,35 @@ def _validate_param_enums_of_type_CDE_enums(
             f"Parameter's '{parameter_spec.label}' enums source '{parameter_spec.enums.source}' does "
             f"not exist in the data model provided."
         )
-    CDE_enums = list(data_model_cdes[parameter_spec.enums.source].enumerations.keys())
-    if parameter_value not in CDE_enums:
+    fixed_var_CDE_enums = list(
+        data_model_cdes[parameter_spec.enums.source].enumerations.keys()
+    )
+    if parameter_value not in fixed_var_CDE_enums:
         raise BadUserInput(
             f"Parameter's '{parameter_spec.label}' enums, that are taken from the CDE '{parameter_spec.enums.source}', "
-            f"should be one of the following: '{list(CDE_enums)}'."
+            f"should be one of the following: '{list(fixed_var_CDE_enums)}'."
         )
 
 
-def _validate_param_enums_of_type_inputdata_CDE_enums(
+def _validate_param_enums_of_type_input_var_CDE_enums(
     parameter_value: Any,
     parameter_spec: ParameterSpecification,
     inputdata: AlgorithmInputDataDTO,
     data_model_cdes: Dict[str, CommonDataElement],
 ):
     if parameter_spec.enums.source == "x":
-        inputdata_vars = inputdata.x
+        input_vars = inputdata.x
     elif parameter_spec.enums.source == "y":
-        inputdata_vars = inputdata.y
+        input_vars = inputdata.y
     else:
         raise NotImplementedError(f"Source should be either 'x' or 'y'.")
-    inputdata_var = inputdata_vars[0]  # multiple=true is not allowed
-    inputdata_CDE_enums = data_model_cdes[inputdata_var].enumerations.keys()
-    if parameter_value not in inputdata_CDE_enums:
+    input_var = input_vars[0]  # multiple=true is not allowed
+    input_var_CDE_enums = data_model_cdes[input_var].enumerations.keys()
+    if parameter_value not in input_var_CDE_enums:
         raise BadUserInput(
-            f"Parameter's '{parameter_spec.label}' enums, that are taken from the CDE '{inputdata_var}' "
+            f"Parameter's '{parameter_spec.label}' enums, that are taken from the CDE '{input_var}' "
             f"given in inputdata '{parameter_spec.enums.source}' variable, "
-            f"should be one of the following: '{list(inputdata_CDE_enums)}'."
+            f"should be one of the following: '{list(input_var_CDE_enums)}'."
         )
 
 

--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -15,6 +15,7 @@ from mipengine.controller.algorithm_specifications import algorithm_specificatio
 from mipengine.controller.api.algorithm_request_dto import USE_SMPC_FLAG
 from mipengine.controller.api.algorithm_request_dto import AlgorithmInputDataDTO
 from mipengine.controller.api.algorithm_request_dto import AlgorithmRequestDTO
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
 from mipengine.controller.node_landscape_aggregator import NodeLandscapeAggregator
 from mipengine.exceptions import BadUserInput
 from mipengine.filters import validate_filter
@@ -293,7 +294,6 @@ def _validate_parameter_type(
         "int": int,
         "real": numbers.Real,
         "boolean": bool,
-        "enum_from_list": (str, int),
         "enum_from_cde": (str, int),
     }
 
@@ -312,10 +312,15 @@ def _validate_parameter_enumerations(
     if parameter_spec.enums is None:
         return
 
-    if parameter_value not in parameter_spec.enums:
-        raise BadUserInput(
-            f"Parameter '{parameter_spec.label}' values "
-            f"should be one of the following: '{str(parameter_spec.enums)}'."
+    if parameter_spec.enums.type == ParameterEnumType.ENUMS_FROM_LIST:
+        if parameter_value not in parameter_spec.enums.source:
+            raise BadUserInput(
+                f"Parameter '{parameter_spec.label}' values "
+                f"should be one of the following: '{str(parameter_spec.enums)}'."
+            )
+    else:
+        raise NotImplementedError(
+            f"Parameter enum type not supported: '{parameter_spec.enums.type}'."
         )
 
 

--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -294,14 +294,14 @@ def _validate_parameter_type(
         "int": int,
         "real": numbers.Real,
         "boolean": bool,
-        "enum_from_cde": (str, int),
     }
 
-    if not isinstance(
-        parameter_value, mip_types_to_python_types[parameter_spec.type.value]
-    ):
+    for param_type in parameter_spec.types:
+        if isinstance(parameter_value, mip_types_to_python_types[param_type.value]):
+            return
+    else:
         raise BadUserInput(
-            f"Parameter '{parameter_spec.label}' values should be of type '{parameter_spec.type}'."
+            f"Parameter '{parameter_spec.label}' values should be of types: {[type.value for type in parameter_spec.types]}."
         )
 
 

--- a/tests/standalone_tests/test_testcase_generator.py
+++ b/tests/standalone_tests/test_testcase_generator.py
@@ -284,7 +284,7 @@ def test_enum_from_cde_parameter():
 def test_make_enum_from_cde_parameter():
     properties = {
         "types": ["int", "text"],
-        "enums": {"type": "inputdata_CDE_enums", "source": "y"},
+        "enums": {"type": "input_var_CDE_enums", "source": "y"},
     }
     variable_groups = {"y": ["a_variable"], "x": []}
     enum = make_parameters(properties, variable_groups)
@@ -294,7 +294,7 @@ def test_make_enum_from_cde_parameter():
 def test_make_enum_from_cde_parameter__error_multiple_vars():
     properties = {
         "types": ["int", "text"],
-        "enums": {"type": "inputdata_CDE_enums", "source": "y"},
+        "enums": {"type": "input_var_CDE_enums", "source": "y"},
     }
     variable_groups = {"y": ["a_variable", "another_one"], "x": []}
     with pytest.raises(AssertionError):

--- a/tests/standalone_tests/test_testcase_generator.py
+++ b/tests/standalone_tests/test_testcase_generator.py
@@ -282,20 +282,20 @@ def test_enum_from_cde_parameter():
 
 
 def test_make_enum_from_cde_parameter():
-    properties = {"type": "enum_from_cde", "variable_group": "y"}
+    properties = {"types": ["enum_from_cde"], "variable_group": "y"}
     variable_groups = {"y": ["a_variable"], "x": []}
     enum = make_parameters(properties, variable_groups)
     assert enum.varname == "a_variable"
 
 
 def test_make_enum_from_cde_parameter__error_multiple_vars():
-    properties = {"type": "enum_from_cde", "variable_group": "y"}
+    properties = {"types": ["enum_from_cde"], "variable_group": "y"}
     variable_groups = {"y": ["a_variable", "another_one"], "x": []}
     with pytest.raises(AssertionError):
         make_parameters(properties, variable_groups)
 
 
 def test_make_enum_from_cde_parameter__error_unknown_type():
-    properties = {"type": "unknown"}
+    properties = {"types": ["unknown"]}
     with pytest.raises(TypeError):
         make_parameters(properties, variable_groups={})

--- a/tests/standalone_tests/test_testcase_generator.py
+++ b/tests/standalone_tests/test_testcase_generator.py
@@ -282,14 +282,20 @@ def test_enum_from_cde_parameter():
 
 
 def test_make_enum_from_cde_parameter():
-    properties = {"types": ["enum_from_cde"], "variable_group": "y"}
+    properties = {
+        "types": ["int", "text"],
+        "enums": {"type": "inputdata_CDE_enums", "source": "y"},
+    }
     variable_groups = {"y": ["a_variable"], "x": []}
     enum = make_parameters(properties, variable_groups)
     assert enum.varname == "a_variable"
 
 
 def test_make_enum_from_cde_parameter__error_multiple_vars():
-    properties = {"types": ["enum_from_cde"], "variable_group": "y"}
+    properties = {
+        "types": ["int", "text"],
+        "enums": {"type": "inputdata_CDE_enums", "source": "y"},
+    }
     variable_groups = {"y": ["a_variable", "another_one"], "x": []}
     with pytest.raises(AssertionError):
         make_parameters(properties, variable_groups)

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -214,6 +214,17 @@ def mock_algorithms_specs():
                         source="non_existing_CDE",
                     ),
                 ),
+                "param_with_enum_type_inputdata_CDEs": ParameterSpecification(
+                    label="cde_enums_param_inputdata_CDEs",
+                    desc="parameter that uses enums with type inputdata_CDEs",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDES,
+                        source=["x", "y"],
+                    ),
+                ),
                 "parameter2": ParameterSpecification(
                     label="parameter2",
                     desc="parameter 2",
@@ -332,6 +343,21 @@ def get_parametrization_list_success_cases():
                 parameters={
                     "parameter1": [1, 3],
                     "param_with_enum_type_cde_enums": "male",
+                },
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model1:0.1",
+                    datasets=["test_dataset1"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1, 3],
+                    "param_with_enum_type_inputdata_CDEs": "test_cde3",
                 },
             ),
         ),
@@ -661,6 +687,25 @@ def get_parametrization_list_exception_cases():
             (
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .*, should be one of the following: .*",
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model2:0.1",
+                    datasets=["test_dataset2"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1],
+                    "param_with_enum_type_inputdata_CDEs": "test_cde4",
+                },
+            ),
+            (
+                BadUserInput,
+                "Parameter's .* enums, that are taken from inputdata .* CDEs, should be one of the following: .*",
             ),
         ),
     ]

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -26,94 +26,59 @@ from mipengine.node_tasks_DTOs import CommonDataElements
 def mock_cdes():
     nla = NodeLandscapeAggregator()
     data_models = {
-        "test_data_model1:0.1": CommonDataElements(
+        "data_model_with_all_cde_types:0.1": CommonDataElements(
             values={
-                "test_cde1": CommonDataElement(
-                    code="test_cde1",
-                    label="test cde1",
+                "int_cde": CommonDataElement(
+                    code="int_cde",
+                    label="int_cde",
                     sql_type="int",
                     is_categorical=False,
-                    enumerations=None,
-                    min=None,
-                    max=None,
                 ),
-                "test_cde2": CommonDataElement(
-                    code="test_cde2",
-                    label="test cde2",
+                "real_cde": CommonDataElement(
+                    code="real_cde",
+                    label="real_cde",
                     sql_type="real",
                     is_categorical=False,
-                    enumerations=None,
-                    min=None,
-                    max=None,
                 ),
-                "test_cde3": CommonDataElement(
-                    code="test_cde3",
-                    label="test cde3",
+                "text_cde_categ": CommonDataElement(
+                    code="text_cde_categ",
+                    label="text_cde_categ",
                     sql_type="text",
                     is_categorical=True,
                     enumerations={"male": "male", "female": "female"},
-                    min=None,
-                    max=None,
                 ),
-                "test_cde4": CommonDataElement(
-                    code="test_cde4",
-                    label="test cde4",
+                "text_cde_non_categ": CommonDataElement(
+                    code="text_cde_non_categ",
+                    label="text_cde_non_categ",
                     sql_type="text",
                     is_categorical=False,
-                    min=None,
-                    max=None,
                 ),
-                "test_cde5": CommonDataElement(
-                    code="test_cde5",
-                    label="test cde5",
+                "int_cde_categ": CommonDataElement(
+                    code="int_cde_categ",
+                    label="int_cde_categ",
                     sql_type="int",
                     is_categorical=True,
                     enumerations={
                         "1": "1",
                         "2": "2",
                     },
-                    min=None,
-                    max=None,
                 ),
-                "test_cde6": CommonDataElement(
-                    code="test_cde6",
-                    label="test cde6",
+                "text_cde_3_enums": CommonDataElement(
+                    code="text_cde_3_enums",
+                    label="text_cde_3_enums",
                     sql_type="text",
                     is_categorical=True,
                     enumerations={"male": "male", "female": "female", "Other": "Other"},
-                    min=None,
-                    max=None,
                 ),
             }
         ),
-        "test_data_model2:0.1": CommonDataElements(
+        "sample_data_model:0.1": CommonDataElements(
             values={
-                "test_cde1": CommonDataElement(
-                    code="test_cde1",
-                    label="test cde1",
+                "sample_cde": CommonDataElement(
+                    code="sample_cde",
+                    label="sample_cde",
                     sql_type="int",
                     is_categorical=False,
-                    enumerations=None,
-                    min=None,
-                    max=None,
-                ),
-                "test_cde2": CommonDataElement(
-                    code="test_cde2",
-                    label="test cde2",
-                    sql_type="real",
-                    is_categorical=False,
-                    enumerations=None,
-                    min=None,
-                    max=None,
-                ),
-                "test_cde3": CommonDataElement(
-                    code="test_cde3",
-                    label="test cde3",
-                    sql_type="text",
-                    is_categorical=True,
-                    enumerations={"male": "male", "female": "female"},
-                    min=None,
-                    max=None,
                 ),
             }
         ),
@@ -133,8 +98,8 @@ def mock_cdes():
 @pytest.fixture()
 def available_datasets_per_data_model():
     d = {
-        "test_data_model1:0.1": ["test_dataset1", "test_dataset2"],
-        "test_data_model2:0.1": ["test_dataset2", "test_dataset3"],
+        "data_model_with_all_cde_types:0.1": ["sample_dataset1", "sample_dataset2"],
+        "sample_data_model:0.1": ["sample_dataset"],
     }
     return d
 
@@ -143,10 +108,26 @@ def available_datasets_per_data_model():
 def mock_algorithms_specs():
     algorithms_specifications = AlgorithmSpecifications()
     algorithms_specifications.enabled_algorithms = {
-        "test_algorithm1": AlgorithmSpecification(
-            name="test algorithm1",
-            desc="test algorithm1",
-            label="test algorithm1",
+        "algorithm_with_y_int": AlgorithmSpecification(
+            name="algorithm_with_y_int",
+            desc="algorithm_with_y_int",
+            label="algorithm_with_y_int",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="features",
+                    desc="Features",
+                    types=["real"],
+                    stattypes=["numerical"],
+                    notblank=True,
+                    multiple=False,
+                ),
+            ),
+        ),
+        "algorithm_with_x_int_and_y_text": AlgorithmSpecification(
+            name="algorithm_with_x_int_and_y_text",
+            desc="algorithm_with_x_int_and_y_text",
+            label="algorithm_with_x_int_and_y_text",
             enabled=True,
             inputdata=InputDataSpecifications(
                 x=InputDataSpecification(
@@ -155,9 +136,72 @@ def mock_algorithms_specs():
                     types=["real"],
                     stattypes=["numerical"],
                     notblank=True,
-                    multiple=True,
-                    enumslen=None,
+                    multiple=False,
                 ),
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["nominal"],
+                    notblank=True,
+                    multiple=False,
+                ),
+            ),
+        ),
+        "algorithm_with_y_text_multiple_true": AlgorithmSpecification(
+            name="algorithm_with_y_text_multiple_true",
+            desc="algorithm_with_y_text_multiple_true",
+            label="algorithm_with_y_text_multiple_true",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["nominal", "numerical"],
+                    notblank=True,
+                    multiple=True,
+                ),
+            ),
+        ),
+        "algorithm_with_y_text_categ": AlgorithmSpecification(
+            name="algorithm_with_y_text_categ",
+            desc="algorithm_with_y_text_categ",
+            label="algorithm_with_y_text_categ",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["nominal"],
+                    notblank=True,
+                    multiple=True,
+                ),
+            ),
+        ),
+        "algorithm_with_y_text_non_categ": AlgorithmSpecification(
+            name="algorithm_with_y_text_non_categ",
+            desc="algorithm_with_y_text_non_categ",
+            label="algorithm_with_y_text_non_categ",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["numerical"],
+                    notblank=True,
+                    multiple=True,
+                ),
+            ),
+        ),
+        "algorithm_with_variable_enumslen": AlgorithmSpecification(
+            name="algorithm_with_variable_enumslen",
+            desc="algorithm_with_variable_enumslen",
+            label="algorithm_with_variable_enumslen",
+            enabled=True,
+            inputdata=InputDataSpecifications(
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
@@ -168,22 +212,120 @@ def mock_algorithms_specs():
                     enumslen=2,
                 ),
             ),
+        ),
+        "algorithm_with_y_and_x_optional": AlgorithmSpecification(
+            name="algorithm_with_y_and_x_optional",
+            desc="algorithm_with_y_and_x_optional",
+            label="algorithm_with_y_and_x_optional",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                x=InputDataSpecification(
+                    label="features",
+                    desc="Features",
+                    types=["real"],
+                    stattypes=["numerical"],
+                    notblank=False,
+                    multiple=False,
+                ),
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["nominal"],
+                    notblank=True,
+                    multiple=False,
+                ),
+            ),
+        ),
+        "algorithm_with_required_param": AlgorithmSpecification(
+            name="algorithm_with_required_param",
+            desc="algorithm_with_required_param",
+            label="algorithm_with_required_param",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="features",
+                    desc="Features",
+                    types=["real"],
+                    stattypes=["numerical"],
+                    notblank=True,
+                    multiple=False,
+                ),
+            ),
             parameters={
-                "parameter1": ParameterSpecification(
-                    label="paremeter1",
-                    desc="parameter 1",
+                "required_param": ParameterSpecification(
+                    label="required_param",
+                    desc="required_param",
                     types=["real"],
                     notblank=True,
+                    multiple=False,
+                ),
+            },
+        ),
+        "algorithm_with_many_params": AlgorithmSpecification(
+            name="algorithm_with_x_and_y",
+            desc="algorithm_with_x_and_y",
+            label="algorithm_with_x_and_y",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="target",
+                    desc="Target variable",
+                    types=["text"],
+                    stattypes=["nominal"],
+                    notblank=True,
+                    multiple=False,
+                ),
+            ),
+            parameters={
+                "int_parameter_with_min_max": ParameterSpecification(
+                    label="parameter_with_min_max",
+                    desc="parameter_with_min_max",
+                    types=["int"],
+                    notblank=False,
+                    multiple=False,
+                    min=2,
+                    max=5,
+                ),
+                "text_parameter": ParameterSpecification(
+                    label="text_parameter",
+                    desc="text_parameter",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                ),
+                "parameter_multiple_true": ParameterSpecification(
+                    label="parameter_multiple_true",
+                    desc="parameter_multiple_true",
+                    types=["int"],
+                    notblank=False,
                     multiple=True,
-                    default=1,
+                ),
+                "param_with_enum_type_list": ParameterSpecification(
+                    label="param_with_enum_type_list",
+                    desc="param_with_enum_type_list",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
                     enums=ParameterEnumSpecification(
                         type=ParameterEnumType.LIST,
-                        source=[1, 2, 3],
+                        source=["a", "b", "c"],
+                    ),
+                ),
+                "param_with_enum_type_list_multiple_true": ParameterSpecification(
+                    label="param_with_enum_type_list_multiple_true",
+                    desc="param_with_enum_type_list_multiple_true",
+                    types=["text"],
+                    notblank=False,
+                    multiple=True,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.LIST,
+                        source=["a", "b", "c"],
                     ),
                 ),
                 "param_with_enum_type_inputdata_cde_enums": ParameterSpecification(
-                    label="inpudata_cde_enums_param",
-                    desc="parameter that uses enums with type inputdata_CDE_enums",
+                    label="param_with_enum_type_inputdata_cde_enums",
+                    desc="param_with_enum_type_inputdata_cde_enums",
                     types=["text"],
                     notblank=False,
                     multiple=False,
@@ -193,14 +335,14 @@ def mock_algorithms_specs():
                     ),
                 ),
                 "param_with_enum_type_cde_enums": ParameterSpecification(
-                    label="cde_enums_param",
-                    desc="parameter that uses enums with type CDE_enums",
+                    label="param_with_enum_type_cde_enums",
+                    desc="param_with_enum_type_cde_enums",
                     types=["text"],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
                         type=ParameterEnumType.CDE_ENUMS,
-                        source="test_cde3",
+                        source="text_cde_categ",
                     ),
                 ),
                 "param_with_enum_type_cde_enums_wrong_CDE": ParameterSpecification(
@@ -225,51 +367,7 @@ def mock_algorithms_specs():
                         source=["x", "y"],
                     ),
                 ),
-                "parameter2": ParameterSpecification(
-                    label="parameter2",
-                    desc="parameter 2",
-                    types=["int"],
-                    notblank=False,
-                    multiple=False,
-                    default=None,
-                    min=2,
-                    max=5,
-                ),
-                "parameter3": ParameterSpecification(
-                    label="parameter3",
-                    desc="parameter 3",
-                    types=["text"],
-                    notblank=False,
-                    multiple=False,
-                    default=None,
-                ),
-                "parameter4": ParameterSpecification(
-                    label="parameter4",
-                    desc="parameter 4",
-                    types=["int"],
-                    notblank=False,
-                    multiple=True,
-                    default=1,
-                ),
             },
-            flags={"formula": False},
-        ),
-        "algorithm_without_x": AlgorithmSpecification(
-            name="algorithm_without_x",
-            desc="algorithm_without_x",
-            label="algorithm_without_x",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="features",
-                    desc="Features",
-                    types=["real"],
-                    stattypes=["numerical"],
-                    notblank=True,
-                    multiple=True,
-                    enumslen=None,
-                ),
-            ),
         ),
     }
 
@@ -282,84 +380,168 @@ def mock_algorithms_specs():
 
 def get_parametrization_list_success_cases():
     parametrization_list = [
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1", "test_dataset2"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1", "sample_dataset2"],
+                    y=["int_cde"],
                 ),
-                parameters={"parameter1": [1, 3], "parameter2": 3},
             ),
+            id="multiple datasets",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_x_int_and_y_text",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2", "test_dataset3"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    x=["int_cde"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1, 3], "parameter2": 3},
             ),
+            id="proper variable types",
         ),
-        (
-            "algorithm_without_x",
+        pytest.param(
+            "algorithm_with_y_text_multiple_true",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2", "test_dataset3"],
-                    y=["test_cde1"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ", "text_cde_non_categ"],
                 ),
             ),
+            id="variables multiple true",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_variable_enumslen",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={
-                    "parameter1": [1, 3],
-                    "param_with_enum_type_inputdata_cde_enums": "male",
-                },
             ),
+            id="variable enumslen",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_and_x_optional",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={
-                    "parameter1": [1, 3],
-                    "param_with_enum_type_cde_enums": "male",
-                },
             ),
+            id="variable notblank false",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_and_x_optional",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={
-                    "parameter1": [1, 3],
-                    "param_with_enum_type_inputdata_CDEs": "test_cde3",
-                },
             ),
+            id="variable notblank false",
+        ),
+        pytest.param(
+            "algorithm_with_required_param",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["int_cde"],
+                ),
+                parameters={"required_param": 1},
+            ),
+            id="parameter required",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"int_parameter_with_min_max": 2},
+            ),
+            id="parameter min max",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"parameter_multiple_true": [1, 2, 3]},
+            ),
+            id="parameter multiple true",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_enum_type_list": "a"},
+            ),
+            id="parameter enums type list",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_enum_type_list_multiple_true": ["a", "c"]},
+            ),
+            id="parameter enums type list and multiple true",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_enum_type_inputdata_cde_enums": "male"},
+            ),
+            id="parameter enums type inputdata_CDE_enums",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_enum_type_cde_enums": "female"},
+            ),
+            id="parameter enums type CDE_enums",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_enum_type_inputdata_CDEs": "text_cde_categ"},
+            ),
+            id="parameter enums type inputdata_CDEs",
         ),
     ]
     return parametrization_list
@@ -380,269 +562,267 @@ def test_validate_algorithm_success(
 
 def get_parametrization_list_exception_cases():
     parametrization_list = [
-        (
+        pytest.param(
             "non_existing_algorithm",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_data"],
-                    x=["lefthippocampus", "righthippocampus"],
-                    y=["alzheimerbroadcategory_bin"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
                 )
             ),
             (BadRequest, "Algorithm .* does not exist."),
+            id="Algorithm does not exist.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_data"],
-                    x=["lefthippocampus", "righthippocampus"],
-                    y=["alzheimerbroadcategory_bin"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["non_existing_dataset"],
+                    y=["int_cde"],
                 )
             ),
             (
                 BadUserInput,
                 "Datasets:.* could not be found for data_model:.*",
             ),
+            id="Dataset does not exist.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="non_existing",
-                    datasets=["test_data"],
-                    x=["lefthippocampus", "righthippocampus"],
-                    y=["alzheimerbroadcategory_bin"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset"],
+                    y=["int_cde"],
+                )
+            ),
+            (
+                BadUserInput,
+                "Datasets:.* could not be found for data_model:.*",
+            ),
+            id="Dataset does not exist in specified data model.",
+        ),
+        pytest.param(
+            "algorithm_with_y_int",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="non_existing_data_model:0.1",
+                    datasets=["sample_dataset"],
+                    y=["int_cde"],
                 )
             ),
             (BadUserInput, "Data model .* does not exist."),
+            id="Data model does not exist.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["non_existing", "non_existing2"],
-                    x=["lefthippocampus", "righthippocampus"],
-                    y=["alzheimerbroadcategory_bin"],
-                )
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                ),
             ),
-            (
-                BadUserInput,
-                "Datasets:.* could not be found for data_model:.*",
-            ),
+            (BadUserInput, "Inputdata .* should be provided."),
+            id="Inputdata not provided.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3", "test_cde2"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ", "real_cde"],
                 )
             ),
             (BadUserInput, "Inputdata .* cannot have multiple values."),
+            id="Inputdata variable with multiple false given list.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
                     y=["non_existing"],
                 )
             ),
             (BadUserInput, "The CDE .* does not exist in the data model provided."),
+            id="CDE does not exist.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_int",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde1"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 )
             ),
             (BadUserInput, "The CDE .* doesn't have one of the allowed types .*"),
+            id="Inputdata variable wrong CDE type.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_text_categ",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde4"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_non_categ"],
                 )
             ),
             (BadUserInput, "The CDE .* should be categorical."),
+            id="Inputdata variable requires categorical CDE given non categorical.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_y_text_non_categ",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde5", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
             ),
             (BadUserInput, "The CDE .* should NOT be categorical."),
+            id="Inputdata variable requires non categorical CDE given categorical.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_variable_enumslen",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde6"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_3_enums"],
                 ),
             ),
             (BadUserInput, "The CDE .* should have .* enumerations."),
+            id="Inputdata variable requires 2 enumerations, CDE has 3 enums.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_required_param",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["int_cde"],
                 ),
             ),
             (BadUserInput, "Algorithm parameters not provided."),
+            id="Required algorithm parameter not provided.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_required_param",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["int_cde"],
                 ),
                 parameters={"wrong_parameter": ""},
             ),
             (BadUserInput, "Parameter .* should not be blank."),
+            id="Required parameter not provided.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": 2},
+                parameters={"parameter_multiple_true": 2},
             ),
             (BadUserInput, "Parameter .* should be a list."),
+            id="Parameter with multiple=true given singular value.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1, 3], "parameter4": [1, 2.3]},
+                parameters={"text_parameter": 1},
             ),
             (BadUserInput, "Parameter .* values should be of types.*"),
+            id="Parameter of type text given int value.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1, 3], "parameter2": "wrong"},
+                parameters={"int_parameter_with_min_max": "text_value"},
             ),
             (BadUserInput, "Parameter .* values should be of types.*"),
+            id="Parameter of type int given text value.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1, 3], "parameter3": 1},
+                parameters={"int_parameter_with_min_max": [1, 2, 3]},
             ),
             (BadUserInput, "Parameter .* values should be of types.*"),
+            id="Parameter of type int with multiple=false given list of ints.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1, 4]},
+                parameters={"param_with_enum_type_list": "non_existing_enum"},
             ),
             (BadUserInput, "Parameter .* values should be one of the following: .*"),
+            id="Parameter with enumerations of type list given non existing enum.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1], "parameter2": 1},
+                parameters={"int_parameter_with_min_max": 1},
             ),
             (BadUserInput, "Parameter .* values should be greater than .*"),
+            id="Parameter with min max given a lesser value.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model1:0.1",
-                    datasets=["test_dataset1"],
-                    x=["test_cde1", "test_cde2"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
-                parameters={"parameter1": [1], "parameter2": 10},
+                parameters={"int_parameter_with_min_max": 10},
             ),
             (BadUserInput, "Parameter .* values should be at most equal to .*"),
+            id="Parameter with min max given a greater value.",
         ),
-        (
-            "algorithm_without_x",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2", "test_dataset3"],
-                ),
-            ),
-            (BadUserInput, "Inputdata .* should be provided."),
-        ),
-        (
-            "test_algorithm1",
-            AlgorithmRequestDTO(
-                inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
                 parameters={
-                    "parameter1": [1],
                     "param_with_enum_type_inputdata_cde_enums": "non_existing_enum",
                 },
             ),
@@ -650,18 +830,17 @@ def get_parametrization_list_exception_cases():
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .* given in inputdata .* variable, should be one of the following: .*",
             ),
+            id="Parameter with enumerations of type inputdata_CDE_enums given non existing enum.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
                 parameters={
-                    "parameter1": [1],
                     "param_with_enum_type_cde_enums_wrong_CDE": "male",
                 },
             ),
@@ -669,18 +848,17 @@ def get_parametrization_list_exception_cases():
                 ValueError,
                 "Parameter's .* enums source .* does not exist in the data model provided.",
             ),
+            id="Parameter with enumerations of type CDE_enums has, in the algorithm specification, a CDE that doesn't exist.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
                 parameters={
-                    "parameter1": [1],
                     "param_with_enum_type_cde_enums": "non_existing_enum",
                 },
             ),
@@ -688,25 +866,25 @@ def get_parametrization_list_exception_cases():
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .*, should be one of the following: .*",
             ),
+            id="Parameter with enumerations of type CDE_enums given non existing enum.",
         ),
-        (
-            "test_algorithm1",
+        pytest.param(
+            "algorithm_with_many_params",
             AlgorithmRequestDTO(
                 inputdata=AlgorithmInputDataDTO(
-                    data_model="test_data_model2:0.1",
-                    datasets=["test_dataset2"],
-                    x=["test_cde1"],
-                    y=["test_cde3"],
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
                 ),
                 parameters={
-                    "parameter1": [1],
-                    "param_with_enum_type_inputdata_CDEs": "test_cde4",
+                    "param_with_enum_type_inputdata_CDEs": "text_cde_non_categ",
                 },
             ),
             (
                 BadUserInput,
                 "Parameter's .* enums, that are taken from inputdata .* CDEs, should be one of the following: .*",
             ),
+            id="Parameter with enumerations of type inputdata_CDEs given non existing enum.",
         ),
     ]
     return parametrization_list

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -6,16 +6,16 @@ from mipengine.controller.algorithm_specifications import AlgorithmSpecification
 from mipengine.controller.algorithm_specifications import AlgorithmSpecifications
 from mipengine.controller.algorithm_specifications import InputDataSpecification
 from mipengine.controller.algorithm_specifications import InputDataSpecifications
+from mipengine.controller.algorithm_specifications import ParameterEnumSpecification
 from mipengine.controller.algorithm_specifications import ParameterSpecification
 from mipengine.controller.api.algorithm_request_dto import AlgorithmInputDataDTO
 from mipengine.controller.api.algorithm_request_dto import AlgorithmRequestDTO
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
 from mipengine.controller.api.validator import BadRequest
 from mipengine.controller.api.validator import validate_algorithm_request
-from mipengine.controller.controller_logger import get_request_logger
 from mipengine.controller.node_landscape_aggregator import DataModelRegistry
 from mipengine.controller.node_landscape_aggregator import DataModelsCDES
 from mipengine.controller.node_landscape_aggregator import NodeLandscapeAggregator
-from mipengine.controller.node_landscape_aggregator import NodeRegistry
 from mipengine.controller.node_landscape_aggregator import _NLARegistries
 from mipengine.exceptions import BadUserInput
 from mipengine.node_tasks_DTOs import CommonDataElement
@@ -176,7 +176,10 @@ def mock_algorithms_specs():
                     notblank=True,
                     multiple=True,
                     default=1,
-                    enums=[1, 2, 3],
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.ENUMS_FROM_LIST,
+                        source=[1, 2, 3],
+                    ),
                 ),
                 "parameter2": ParameterSpecification(
                     label="paremeter2",

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -181,8 +181,8 @@ def mock_algorithms_specs():
                         source=[1, 2, 3],
                     ),
                 ),
-                "parameter_with_param_enum_inputdata_cde_enums": ParameterSpecification(
-                    label="parameter",
+                "param_with_enum_type_inputdata_cde_enums": ParameterSpecification(
+                    label="inpudata_cde_enums_param",
                     desc="parameter that uses enums with type inputdata_CDE_enums",
                     types=["text"],
                     notblank=False,
@@ -190,6 +190,28 @@ def mock_algorithms_specs():
                     enums=ParameterEnumSpecification(
                         type=ParameterEnumType.INPUTDATA_CDE_ENUMS,
                         source="y",
+                    ),
+                ),
+                "param_with_enum_type_cde_enums": ParameterSpecification(
+                    label="cde_enums_param",
+                    desc="parameter that uses enums with type CDE_enums",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.CDE_ENUMS,
+                        source="test_cde3",
+                    ),
+                ),
+                "param_with_enum_type_cde_enums_wrong_CDE": ParameterSpecification(
+                    label="cde_enums_param_wrong_CDE",
+                    desc="parameter that uses enums with type CDE_enums",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.CDE_ENUMS,
+                        source="non_existing_CDE",
                     ),
                 ),
                 "parameter2": ParameterSpecification(
@@ -294,7 +316,22 @@ def get_parametrization_list_success_cases():
                 ),
                 parameters={
                     "parameter1": [1, 3],
-                    "parameter_with_param_enum_inputdata_cde_enums": "male",
+                    "param_with_enum_type_inputdata_cde_enums": "male",
+                },
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model1:0.1",
+                    datasets=["test_dataset1"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1, 3],
+                    "param_with_enum_type_cde_enums": "male",
                 },
             ),
         ),
@@ -580,12 +617,50 @@ def get_parametrization_list_exception_cases():
                 ),
                 parameters={
                     "parameter1": [1],
-                    "parameter_with_param_enum_inputdata_cde_enums": "non_existing_enum",
+                    "param_with_enum_type_inputdata_cde_enums": "non_existing_enum",
                 },
             ),
             (
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .* given in inputdata .* variable, should be one of the following: .*",
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model2:0.1",
+                    datasets=["test_dataset2"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1],
+                    "param_with_enum_type_cde_enums_wrong_CDE": "male",
+                },
+            ),
+            (
+                ValueError,
+                "Parameter's .* enums source .* does not exist in the data model provided.",
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model2:0.1",
+                    datasets=["test_dataset2"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1],
+                    "param_with_enum_type_cde_enums": "non_existing_enum",
+                },
+            ),
+            (
+                BadUserInput,
+                "Parameter's .* enums, that are taken from the CDE .*, should be one of the following: .*",
             ),
         ),
     ]

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -323,47 +323,47 @@ def mock_algorithms_specs():
                         source=["a", "b", "c"],
                     ),
                 ),
-                "param_with_enum_type_inputdata_cde_enums": ParameterSpecification(
-                    label="param_with_enum_type_inputdata_cde_enums",
-                    desc="param_with_enum_type_inputdata_cde_enums",
+                "param_with_enum_type_input_var_CDE_enums": ParameterSpecification(
+                    label="param_with_enum_type_input_var_CDE_enums",
+                    desc="param_with_enum_type_input_var_CDE_enums",
                     types=["text"],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS,
+                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS,
                         source="y",
                     ),
                 ),
-                "param_with_enum_type_cde_enums": ParameterSpecification(
-                    label="param_with_enum_type_cde_enums",
-                    desc="param_with_enum_type_cde_enums",
+                "param_with_enum_type_fixed_var_CDE_enums": ParameterSpecification(
+                    label="param_with_enum_type_fixed_var_CDE_enums",
+                    desc="param_with_enum_type_fixed_var_CDE_enums",
                     types=["text"],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.CDE_ENUMS,
+                        type=ParameterEnumType.FIXED_VAR_CDE_ENUMS,
                         source="text_cde_categ",
                     ),
                 ),
-                "param_with_enum_type_cde_enums_wrong_CDE": ParameterSpecification(
-                    label="cde_enums_param_wrong_CDE",
-                    desc="parameter that uses enums with type CDE_enums",
+                "param_with_enum_type_fixed_var_CDE_enums_wrong_CDE": ParameterSpecification(
+                    label="param_with_enum_type_fixed_var_CDE_enums_wrong_CDE",
+                    desc="param_with_enum_type_fixed_var_CDE_enums_wrong_CDE",
                     types=["text"],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.CDE_ENUMS,
+                        type=ParameterEnumType.FIXED_VAR_CDE_ENUMS,
                         source="non_existing_CDE",
                     ),
                 ),
-                "param_with_enum_type_inputdata_CDEs": ParameterSpecification(
-                    label="cde_enums_param_inputdata_CDEs",
-                    desc="parameter that uses enums with type inputdata_CDEs",
+                "param_with_enum_type_input_var_names": ParameterSpecification(
+                    label="param_with_enum_type_input_var_names",
+                    desc="param_with_enum_type_input_var_names",
                     types=["text"],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDES,
+                        type=ParameterEnumType.INPUT_VAR_NAMES,
                         source=["x", "y"],
                     ),
                 ),
@@ -515,9 +515,9 @@ def get_parametrization_list_success_cases():
                     datasets=["sample_dataset1"],
                     y=["text_cde_categ"],
                 ),
-                parameters={"param_with_enum_type_inputdata_cde_enums": "male"},
+                parameters={"param_with_enum_type_input_var_CDE_enums": "male"},
             ),
-            id="parameter enums type inputdata_CDE_enums",
+            id="parameter enums type input_var_CDE_enums",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -527,9 +527,9 @@ def get_parametrization_list_success_cases():
                     datasets=["sample_dataset1"],
                     y=["text_cde_categ"],
                 ),
-                parameters={"param_with_enum_type_cde_enums": "female"},
+                parameters={"param_with_enum_type_fixed_var_CDE_enums": "female"},
             ),
-            id="parameter enums type CDE_enums",
+            id="parameter enums type fixed_var_CDE_enums",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -539,9 +539,9 @@ def get_parametrization_list_success_cases():
                     datasets=["sample_dataset1"],
                     y=["text_cde_categ"],
                 ),
-                parameters={"param_with_enum_type_inputdata_CDEs": "text_cde_categ"},
+                parameters={"param_with_enum_type_input_var_names": "text_cde_categ"},
             ),
-            id="parameter enums type inputdata_CDEs",
+            id="parameter enums type input_var_names",
         ),
     ]
     return parametrization_list
@@ -823,14 +823,14 @@ def get_parametrization_list_exception_cases():
                     y=["text_cde_categ"],
                 ),
                 parameters={
-                    "param_with_enum_type_inputdata_cde_enums": "non_existing_enum",
+                    "param_with_enum_type_input_var_CDE_enums": "non_existing_enum",
                 },
             ),
             (
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .* given in inputdata .* variable, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type inputdata_CDE_enums given non existing enum.",
+            id="Parameter with enumerations of type input_var_CDE_enums given non existing enum.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -841,14 +841,14 @@ def get_parametrization_list_exception_cases():
                     y=["text_cde_categ"],
                 ),
                 parameters={
-                    "param_with_enum_type_cde_enums_wrong_CDE": "male",
+                    "param_with_enum_type_fixed_var_CDE_enums_wrong_CDE": "male",
                 },
             ),
             (
                 ValueError,
                 "Parameter's .* enums source .* does not exist in the data model provided.",
             ),
-            id="Parameter with enumerations of type CDE_enums has, in the algorithm specification, a CDE that doesn't exist.",
+            id="Parameter with enumerations of type fixed_var_CDE_enums has, in the algorithm specification, a CDE that doesn't exist.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -859,14 +859,14 @@ def get_parametrization_list_exception_cases():
                     y=["text_cde_categ"],
                 ),
                 parameters={
-                    "param_with_enum_type_cde_enums": "non_existing_enum",
+                    "param_with_enum_type_fixed_var_CDE_enums": "non_existing_enum",
                 },
             ),
             (
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .*, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type CDE_enums given non existing enum.",
+            id="Parameter with enumerations of type fixed_var_CDE_enums given non existing enum.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -877,14 +877,14 @@ def get_parametrization_list_exception_cases():
                     y=["text_cde_categ"],
                 ),
                 parameters={
-                    "param_with_enum_type_inputdata_CDEs": "text_cde_non_categ",
+                    "param_with_enum_type_input_var_names": "text_cde_non_categ",
                 },
             ),
             (
                 BadUserInput,
-                "Parameter's .* enums, that are taken from inputdata .* CDEs, should be one of the following: .*",
+                "Parameter's .* enums, that are taken from inputdata .* var names, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type inputdata_CDEs given non existing enum.",
+            id="Parameter with enumerations of type input_var_names given non existing enum.",
         ),
     ]
     return parametrization_list

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -172,7 +172,7 @@ def mock_algorithms_specs():
                 "parameter1": ParameterSpecification(
                     label="paremeter1",
                     desc="parameter 1",
-                    type="real",
+                    types=["real"],
                     notblank=True,
                     multiple=True,
                     default=1,
@@ -184,7 +184,7 @@ def mock_algorithms_specs():
                 "parameter2": ParameterSpecification(
                     label="paremeter2",
                     desc="parameter 2",
-                    type="int",
+                    types=["int"],
                     notblank=False,
                     multiple=False,
                     default=None,
@@ -194,7 +194,7 @@ def mock_algorithms_specs():
                 "parameter3": ParameterSpecification(
                     label="paremeter3",
                     desc="parameter 3",
-                    type="text",
+                    types=["text"],
                     notblank=False,
                     multiple=False,
                     default=None,
@@ -202,7 +202,7 @@ def mock_algorithms_specs():
                 "parameter4": ParameterSpecification(
                     label="paremeter4",
                     desc="parameter 4",
-                    type="int",
+                    types=["int"],
                     notblank=False,
                     multiple=True,
                     default=1,
@@ -466,7 +466,7 @@ def get_parametrization_list_exception_cases():
                 ),
                 parameters={"parameter1": [1, 3], "parameter4": [1, 2.3]},
             ),
-            (BadUserInput, "Parameter .* values should be of type .*"),
+            (BadUserInput, "Parameter .* values should be of types.*"),
         ),
         (
             "test_algorithm1",
@@ -479,7 +479,7 @@ def get_parametrization_list_exception_cases():
                 ),
                 parameters={"parameter1": [1, 3], "parameter2": "wrong"},
             ),
-            (BadUserInput, "Parameter .* values should be of type .*"),
+            (BadUserInput, "Parameter .* values should be of types.*"),
         ),
         (
             "test_algorithm1",
@@ -492,7 +492,7 @@ def get_parametrization_list_exception_cases():
                 ),
                 parameters={"parameter1": [1, 3], "parameter3": 1},
             ),
-            (BadUserInput, "Parameter .* values should be of type .*"),
+            (BadUserInput, "Parameter .* values should be of types.*"),
         ),
         (
             "test_algorithm1",

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -177,12 +177,23 @@ def mock_algorithms_specs():
                     multiple=True,
                     default=1,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.ENUMS_FROM_LIST,
+                        type=ParameterEnumType.LIST,
                         source=[1, 2, 3],
                     ),
                 ),
+                "parameter_with_param_enum_inputdata_cde_enums": ParameterSpecification(
+                    label="parameter",
+                    desc="parameter that uses enums with type inputdata_CDE_enums",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS,
+                        source="y",
+                    ),
+                ),
                 "parameter2": ParameterSpecification(
-                    label="paremeter2",
+                    label="parameter2",
                     desc="parameter 2",
                     types=["int"],
                     notblank=False,
@@ -192,7 +203,7 @@ def mock_algorithms_specs():
                     max=5,
                 ),
                 "parameter3": ParameterSpecification(
-                    label="paremeter3",
+                    label="parameter3",
                     desc="parameter 3",
                     types=["text"],
                     notblank=False,
@@ -200,7 +211,7 @@ def mock_algorithms_specs():
                     default=None,
                 ),
                 "parameter4": ParameterSpecification(
-                    label="paremeter4",
+                    label="parameter4",
                     desc="parameter 4",
                     types=["int"],
                     notblank=False,
@@ -270,6 +281,21 @@ def get_parametrization_list_success_cases():
                     datasets=["test_dataset2", "test_dataset3"],
                     y=["test_cde1"],
                 ),
+            ),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model1:0.1",
+                    datasets=["test_dataset1"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1, 3],
+                    "parameter_with_param_enum_inputdata_cde_enums": "male",
+                },
             ),
         ),
     ]
@@ -367,7 +393,7 @@ def get_parametrization_list_exception_cases():
                     y=["non_existing"],
                 )
             ),
-            (BadUserInput, "The CDE .* does not exist in data model .*"),
+            (BadUserInput, "The CDE .* does not exist in the data model provided."),
         ),
         (
             "test_algorithm1",
@@ -542,6 +568,25 @@ def get_parametrization_list_exception_cases():
                 ),
             ),
             (BadUserInput, "Inputdata .* should be provided."),
+        ),
+        (
+            "test_algorithm1",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="test_data_model2:0.1",
+                    datasets=["test_dataset2"],
+                    x=["test_cde1"],
+                    y=["test_cde3"],
+                ),
+                parameters={
+                    "parameter1": [1],
+                    "parameter_with_param_enum_inputdata_cde_enums": "non_existing_enum",
+                },
+            ),
+            (
+                BadUserInput,
+                "Parameter's .* enums, that are taken from the CDE .* given in inputdata .* variable, should be one of the following: .*",
+            ),
         ),
     ]
     return parametrization_list

--- a/tests/standalone_tests/test_validate_algorithm_specifications.py
+++ b/tests/standalone_tests/test_validate_algorithm_specifications.py
@@ -9,6 +9,7 @@ from mipengine.controller.algorithm_specifications import ParameterSpecification
 from mipengine.controller.api.algorithm_specifications_dtos import InputDataStatType
 from mipengine.controller.api.algorithm_specifications_dtos import InputDataType
 from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterType
 
 
 def test_validate_parameter_spec_inputdata_CDE_enums_source_is_x_or_y():
@@ -37,7 +38,7 @@ def test_validate_parameter_spec_inputdata_CDE_enums_source_is_x_or_y():
                 "inputdata_cde_enum_param": ParameterSpecification(
                     label="sample_label",
                     desc="sample",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
@@ -74,7 +75,7 @@ def test_validate_parameter_spec_inputdata_CDE_enums_multiple_false():
                 "inputdata_cde_enum_param": ParameterSpecification(
                     label="sample_label",
                     desc="sample",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=True,
                     enums=ParameterEnumSpecification(
@@ -88,7 +89,7 @@ def test_validate_parameter_spec_inputdata_CDE_enums_multiple_false():
 def test_validate_parameter_spec_inputdata_CDE_enums_inputdata_has_multiple_false():
     exception_type = ValidationError
     exception_message = (
-        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        ".* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
         "that doesn't support 'multiple=True' in it's linked inputdata var 'y'.*"
     )
     with pytest.raises(exception_type, match=exception_message):
@@ -111,11 +112,48 @@ def test_validate_parameter_spec_inputdata_CDE_enums_inputdata_has_multiple_fals
                 "inputdata_cde_enum_param": ParameterSpecification(
                     label="sample_label",
                     desc="sample",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
                         type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="y"
+                    ),
+                ),
+            },
+        )
+
+
+def test_validate_parameter_spec_inputdata_CDEs_type_must_be_text():
+    exception_type = ValidationError
+    exception_message = (
+        """.* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDEs' """
+        """that supports ONLY '.*' but the 'types' provided were .*"""
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=True,
+                )
+            ),
+            parameters={
+                "inputdata_cdes_enum_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=[ParameterType.INT],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDES, source=["y"]
                     ),
                 ),
             },

--- a/tests/standalone_tests/test_validate_algorithm_specifications.py
+++ b/tests/standalone_tests/test_validate_algorithm_specifications.py
@@ -12,10 +12,10 @@ from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnum
 from mipengine.controller.api.algorithm_specifications_dtos import ParameterType
 
 
-def test_validate_parameter_spec_inputdata_CDE_enums_source_is_x_or_y():
+def test_validate_parameter_spec_input_var_CDE_enums_source_is_x_or_y():
     exception_type = ValidationError
     exception_message = (
-        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'input_var_CDE_enums' "
         "that supports only 'x' or 'y' as source. Value given: 'not_x_or_y'.*"
     )
     with pytest.raises(exception_type, match=exception_message):
@@ -42,17 +42,17 @@ def test_validate_parameter_spec_inputdata_CDE_enums_source_is_x_or_y():
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="not_x_or_y"
+                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS, source="not_x_or_y"
                     ),
                 ),
             },
         )
 
 
-def test_validate_parameter_spec_inputdata_CDE_enums_multiple_false():
+def test_validate_parameter_spec_input_var_CDE_enums_multiple_false():
     exception_type = ValidationError
     exception_message = (
-        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'input_var_CDE_enums' "
         "that doesn't support 'multiple=True', in the parameter.*"
     )
     with pytest.raises(exception_type, match=exception_message):
@@ -79,17 +79,17 @@ def test_validate_parameter_spec_inputdata_CDE_enums_multiple_false():
                     notblank=False,
                     multiple=True,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="y"
+                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS, source="y"
                     ),
                 ),
             },
         )
 
 
-def test_validate_parameter_spec_inputdata_CDE_enums_inputdata_has_multiple_false():
+def test_validate_parameter_spec_input_var_CDE_enums_inputdata_has_multiple_false():
     exception_type = ValidationError
     exception_message = (
-        ".* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        ".* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'input_var_CDE_enums' "
         "that doesn't support 'multiple=True' in it's linked inputdata var 'y'.*"
     )
     with pytest.raises(exception_type, match=exception_message):
@@ -116,17 +116,17 @@ def test_validate_parameter_spec_inputdata_CDE_enums_inputdata_has_multiple_fals
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="y"
+                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS, source="y"
                     ),
                 ),
             },
         )
 
 
-def test_validate_parameter_spec_inputdata_CDEs_type_must_be_text():
+def test_validate_parameter_spec_input_var_names_type_must_be_text():
     exception_type = ValidationError
     exception_message = (
-        """.* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDEs' """
+        """.* In algorithm 'sample_algo', parameter 'sample_label' has enums type 'input_var_names' """
         """that supports ONLY '.*' but the 'types' provided were .*"""
     )
     with pytest.raises(exception_type, match=exception_message):
@@ -146,14 +146,14 @@ def test_validate_parameter_spec_inputdata_CDEs_type_must_be_text():
                 )
             ),
             parameters={
-                "inputdata_cdes_enum_param": ParameterSpecification(
+                "input_var_names_enum_param": ParameterSpecification(
                     label="sample_label",
                     desc="sample",
                     types=[ParameterType.INT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUTDATA_CDES, source=["y"]
+                        type=ParameterEnumType.INPUT_VAR_NAMES, source=["y"]
                     ),
                 ),
             },

--- a/tests/standalone_tests/test_validate_algorithm_specifications.py
+++ b/tests/standalone_tests/test_validate_algorithm_specifications.py
@@ -1,0 +1,122 @@
+import pytest
+from pydantic import ValidationError
+
+from mipengine.controller.algorithm_specifications import AlgorithmSpecification
+from mipengine.controller.algorithm_specifications import InputDataSpecification
+from mipengine.controller.algorithm_specifications import InputDataSpecifications
+from mipengine.controller.algorithm_specifications import ParameterEnumSpecification
+from mipengine.controller.algorithm_specifications import ParameterSpecification
+from mipengine.controller.api.algorithm_specifications_dtos import InputDataStatType
+from mipengine.controller.api.algorithm_specifications_dtos import InputDataType
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
+
+
+def test_validate_parameter_spec_inputdata_CDE_enums_source_is_x_or_y():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        "that supports only 'x' or 'y' as source. Value given: 'not_x_or_y'.*"
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "inputdata_cde_enum_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="not_x_or_y"
+                    ),
+                ),
+            },
+        )
+
+
+def test_validate_parameter_spec_inputdata_CDE_enums_multiple_false():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        "that doesn't support 'multiple=True', in the parameter.*"
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "inputdata_cde_enum_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=["text"],
+                    notblank=False,
+                    multiple=True,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="y"
+                    ),
+                ),
+            },
+        )
+
+
+def test_validate_parameter_spec_inputdata_CDE_enums_inputdata_has_multiple_false():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has enums type 'inputdata_CDE_enums' "
+        "that doesn't support 'multiple=True' in it's linked inputdata var 'y'.*"
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=True,
+                )
+            ),
+            parameters={
+                "inputdata_cde_enum_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=["text"],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUTDATA_CDE_ENUMS, source="y"
+                    ),
+                ),
+            },
+        )

--- a/tests/testcase_generators/testcase_generator.py
+++ b/tests/testcase_generators/testcase_generator.py
@@ -254,20 +254,19 @@ class EnumFromCDE(AlgorithmParameter):
 
 
 def make_parameters(properties, variable_groups):
-    if properties["type"] == "int":
-        return IntegerParameter(min=properties["min"], max=properties["max"])
-    if properties["type"] == "float":
+    if "float" in properties["types"]:
         return FloatParameter(min=properties["min"], max=properties["max"])
+    if "int" in properties["types"]:
+        return IntegerParameter(min=properties["min"], max=properties["max"])
     if "enums" in properties and properties["enums"]["type"] == "enums_from_list":
         return EnumFromList(enums=properties["enums"]["source"])
-    if properties["type"] == "enum_from_cde":
+    if "enum_from_cde" in properties["types"]:
         var_group_key = properties["variable_group"]
         var_group = variable_groups[var_group_key]
         assert len(var_group) == 1, "EnumFromCDE doesn't work when multiple=True"
         varname = var_group[0]
         return EnumFromCDE(varname=varname)
-    else:
-        raise TypeError(f"Unknown parameter type: {properties['type']}.")
+    raise TypeError(f"Unknown parameter type: {properties['types']}.")
 
 
 class InputGenerator:

--- a/tests/testcase_generators/testcase_generator.py
+++ b/tests/testcase_generators/testcase_generator.py
@@ -254,18 +254,19 @@ class EnumFromCDE(AlgorithmParameter):
 
 
 def make_parameters(properties, variable_groups):
-    if "float" in properties["types"]:
-        return FloatParameter(min=properties["min"], max=properties["max"])
-    if "int" in properties["types"]:
-        return IntegerParameter(min=properties["min"], max=properties["max"])
-    if "enums" in properties and properties["enums"]["type"] == "enums_from_list":
+    if "enums" in properties and properties["enums"]["type"] == "list":
         return EnumFromList(enums=properties["enums"]["source"])
-    if "enum_from_cde" in properties["types"]:
-        var_group_key = properties["variable_group"]
+    if "enums" in properties and properties["enums"]["type"] == "inputdata_CDE_enums":
+        var_group_key = properties["enums"]["source"]
         var_group = variable_groups[var_group_key]
         assert len(var_group) == 1, "EnumFromCDE doesn't work when multiple=True"
         varname = var_group[0]
         return EnumFromCDE(varname=varname)
+    if "float" in properties["types"]:
+        return FloatParameter(min=properties["min"], max=properties["max"])
+    if "int" in properties["types"]:
+        return IntegerParameter(min=properties["min"], max=properties["max"])
+
     raise TypeError(f"Unknown parameter type: {properties['types']}.")
 
 

--- a/tests/testcase_generators/testcase_generator.py
+++ b/tests/testcase_generators/testcase_generator.py
@@ -256,7 +256,7 @@ class EnumFromCDE(AlgorithmParameter):
 def make_parameters(properties, variable_groups):
     if "enums" in properties and properties["enums"]["type"] == "list":
         return EnumFromList(enums=properties["enums"]["source"])
-    if "enums" in properties and properties["enums"]["type"] == "inputdata_CDE_enums":
+    if "enums" in properties and properties["enums"]["type"] == "input_var_CDE_enums":
         var_group_key = properties["enums"]["source"]
         var_group = variable_groups[var_group_key]
         assert len(var_group) == 1, "EnumFromCDE doesn't work when multiple=True"

--- a/tests/testcase_generators/testcase_generator.py
+++ b/tests/testcase_generators/testcase_generator.py
@@ -258,8 +258,8 @@ def make_parameters(properties, variable_groups):
         return IntegerParameter(min=properties["min"], max=properties["max"])
     if properties["type"] == "float":
         return FloatParameter(min=properties["min"], max=properties["max"])
-    if properties["type"] == "enum_from_list":
-        return EnumFromList(enums=properties["enums"])
+    if "enums" in properties and properties["enums"]["type"] == "enums_from_list":
+        return EnumFromList(enums=properties["enums"]["source"])
     if properties["type"] == "enum_from_cde":
         var_group_key = properties["variable_group"]
         var_group = variable_groups[var_group_key]


### PR DESCRIPTION
Changelog:
  - Add support for additional enum types in algorithm specifications. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-758)
  - Small refactoring on the `AlgorithmSpecifications`, separated them from the DTOs completely.
  - Parameter `type` renamed to `types` and can now have multiple values.