### PR TITLE
UDF generator refactor: replace `generate_udf_queries` with class

### DIFF
--- a/mipengine/algorithms/preprocessing.py
+++ b/mipengine/algorithms/preprocessing.py
@@ -438,7 +438,8 @@ class FormulaTransformer:
         import pandas as pd
         from patsy import dmatrix
 
-        empty_df = pd.DataFrame(columns=old_column_names)
+        empty_data = {col: [] for col in old_column_names}
+        empty_df = pd.DataFrame(data=empty_data)
         for var, categories in enums.items():
             empty_df[var] = pd.Categorical(empty_df[var], categories=categories)
         mat = dmatrix(self._formula, empty_df)

--- a/mipengine/node/monetdb_interface/common_actions.py
+++ b/mipengine/node/monetdb_interface/common_actions.py
@@ -28,7 +28,7 @@ def create_table_name(
     node_id: str,
     context_id: str,
     command_id: str,
-    command_subid: str = "0",
+    result_id: str = "0",
 ) -> str:
     """
     Creates and returns in lower case a table name with the format
@@ -42,15 +42,13 @@ def create_table_name(
         raise ValueError(f"'context_id' is not alphanumeric. Value: '{context_id}'")
     if not command_id.isalnum():
         raise ValueError(f"'command_id' is not alphanumeric. Value: '{command_id}'")
-    if not command_subid.isalnum():
-        raise ValueError(
-            f"'command_subid' is not alphanumeric. Value: '{command_subid}'"
-        )
+    if not result_id.isalnum():
+        raise ValueError(f"'result_id' is not alphanumeric. Value: '{result_id}'")
 
     if table_type not in {TableType.NORMAL, TableType.VIEW, TableType.MERGE}:
         raise TypeError(f"Table type is not acceptable: {table_type} .")
 
-    return f"{table_type}_{node_id}_{context_id}_{command_id}_{command_subid}".lower()
+    return f"{table_type}_{node_id}_{context_id}_{command_id}_{result_id}".lower()
 
 
 def convert_schema_to_sql_query_format(schema: TableSchema) -> str:

--- a/mipengine/node/tasks/udfs.py
+++ b/mipengine/node/tasks/udfs.py
@@ -28,28 +28,21 @@ from mipengine.node_tasks_DTOs import SMPCTablesInfo
 from mipengine.node_tasks_DTOs import TableInfo
 from mipengine.node_tasks_DTOs import TableSchema
 from mipengine.node_tasks_DTOs import TableType
-from mipengine.node_tasks_DTOs import _NodeUDFDTOType
 from mipengine.smpc_cluster_comm_helpers import validate_smpc_usage
-from mipengine.udfgen import generate_udf_queries
-from mipengine.udfgen.udfgen_DTOs import UDFGenExecutionQueries
+from mipengine.udfgen import FlowUdfArg
+from mipengine.udfgen import UdfGenerator
+from mipengine.udfgen import udf
 from mipengine.udfgen.udfgen_DTOs import UDFGenResult
 from mipengine.udfgen.udfgen_DTOs import UDFGenSMPCResult
 from mipengine.udfgen.udfgen_DTOs import UDFGenTableResult
-from mipengine.udfgen.udfgenerator import UDFGenArgument
-from mipengine.udfgen.udfgenerator import udf as udf_registry
 
 
 @shared_task
 @initialise_logger
 def get_udf(request_id: str, func_name: str) -> str:
-    return str(udf_registry.registry[func_name])
+    return str(udf.registry[func_name])
 
 
-# TODO https://team-1617704806227.atlassian.net/browse/MIP-473
-# @shared_task(
-#     soft_time_limit=node_config.celery.run_udf_soft_time_limit,
-#     time_limit=node_config.celery.run_udf_time_limit,
-# )
 @shared_task
 @initialise_logger
 def run_udf(
@@ -94,10 +87,8 @@ def run_udf(
     positional_args = NodeUDFPosArguments.parse_raw(positional_args_json)
     keyword_args = NodeUDFKeyArguments.parse_raw(keyword_args_json)
 
-    if output_schema:
-        output_schema = _convert_tableschema2udfgen_iotype(
-            TableSchema.parse_raw(output_schema)
-        )
+    if output_schema is not None:
+        output_schema = _convert_output_schema(output_schema)
 
     udf_statements, udf_results = _generate_udf_statements(
         request_id=request_id,
@@ -115,10 +106,9 @@ def run_udf(
     return udf_results.json()
 
 
-def _convert_tableschema2udfgen_iotype(
-    output_schema: TableSchema,
-) -> List[Tuple[str, DType]]:
-    return [(col.name, col.dtype) for col in output_schema.columns]
+def _convert_output_schema(output_schema: str) -> List[Tuple[str, DType]]:
+    table_schema = TableSchema.parse_raw(output_schema)
+    return [(col.name, col.dtype) for col in table_schema.columns]
 
 
 @shared_task
@@ -157,6 +147,7 @@ def get_run_udf_query(
             A list of the statements that would be executed in the DB.
 
     """
+    # TODO why should we validate here?
     validate_smpc_usage(use_smpc, node_config.smpc.enabled, node_config.smpc.optional)
 
     positional_args = NodeUDFPosArguments.parse_raw(positional_args_json)
@@ -183,274 +174,69 @@ def _create_udf_name(func_name: str, command_id: str, context_id: str) -> str:
     return f"{func_name}_{command_id}_{context_id}"
 
 
-def _convert_nodeudf2udfgen_args(
+def _convert_nodeudf_to_flow_args(
     positional_args: NodeUDFPosArguments,
     keyword_args: NodeUDFKeyArguments,
-) -> Tuple[List[UDFGenArgument], Dict[str, UDFGenArgument]]:
+) -> Tuple[List[FlowUdfArg], Dict[str, FlowUdfArg]]:
     """
-    The input arguments are received from the controller and contain
-    the value of the argument (literal) or information
-    about the location of the input (tablename).
+    Converts UDF arguments DTOs in format understood by UDF generator
 
-    This method adds information on these arguments, that will be
-    sent to the udfgenerator.
-
-    The udfgen args can be of number, TableInfo or SMPCUDFInput type.
+    The input arguments are received from the controller and contain the value
+    of the argument (literal) or information about the location of the input
+    (tablename). This function creates new objects with added information
+    necessary for the UDF generator. These objects are named FlowUdfArgs
+    because, in the context of the UDF generator, they come from the algorithm
+    flow.
 
     Parameters
     ----------
-    positional_args The pos arguments received from the controller.
-    keyword_args The kw arguments received from the controller.
+    positional_args : NodeUDFPosArguments
+        The pos arguments received from the controller.
+    keyword_args : NodeUDFKeyArguments
+        The kw arguments received from the controller.
 
     Returns
     -------
-    The same arguments (pos/kw) in a udfgen argument structure.
+    List[FlowUdfArg]
+        Args for the UDF generator.
+    Dict[str, FlowUdfArg]
+        Kwargs for the UDF generator.
     """
-    generator_pos_args = [
-        _convert_nodeudf2udfgen_arg(pos_arg) for pos_arg in positional_args.args
-    ]
 
-    generator_kw_args = {
-        key: _convert_nodeudf2udfgen_arg(argument)
-        for key, argument in keyword_args.args.items()
-    }
+    def convert(arg: NodeUDFDTO) -> FlowUdfArg:
+        if isinstance(arg, NodeTableDTO):
+            _validate_tableinfo_type_matches_actual_tabletype(arg.value)
+            return arg.value
+        elif isinstance(arg, NodeSMPCDTO):
+            _validate_smpctablesinfo_type_matches_actual_tablestype(arg.value)
+            return arg.value
+        elif isinstance(arg, NodeLiteralDTO):
+            return arg.value
+        raise ValueError(f"A UDF argument needs to be an instance of {NodeUDFDTO}'.")
 
-    return generator_pos_args, generator_kw_args
+    flowargs = [convert(arg) for arg in positional_args.args]
 
+    flowkwargs = {key: convert(arg) for key, arg in keyword_args.args.items()}
 
-def _convert_nodeudf2udfgen_arg(udf_argument: NodeUDFDTO) -> UDFGenArgument:
-    if isinstance(udf_argument, NodeTableDTO):
-        validate_tableinfo_type_matches_actual_tabletype(udf_argument.value)
-        return udf_argument.value
-    elif isinstance(udf_argument, NodeSMPCDTO):
-        validate_smpctablesinfo_type_matches_actual_tablestype(udf_argument.value)
-        return udf_argument.value
-    elif isinstance(udf_argument, NodeLiteralDTO):
-        return udf_argument.value
-    else:
-        argument_kinds = ",".join([str(k) for k in _NodeUDFDTOType])
-        raise ValueError(
-            f"A udf argument can have one of the following types {argument_kinds}'."
-        )
+    return flowargs, flowkwargs
 
 
-def validate_tableinfo_type_matches_actual_tabletype(table_info: TableInfo):
+def _validate_tableinfo_type_matches_actual_tabletype(table_info: TableInfo):
     if table_info.type_ != get_table_type(table_info.name):
-        raise ValueError(
-            f"Table: '{table_info.name}' is not of type: '{table_info.type_}'."
-        )
+        msg = f"Table: '{table_info.name}' is not of type: '{table_info.type_}'."
+        raise ValueError(msg)
 
 
-def validate_smpctablesinfo_type_matches_actual_tablestype(tables_info: SMPCTablesInfo):
-    validate_tableinfo_type_matches_actual_tabletype(tables_info.template)
-    validate_tableinfo_type_matches_actual_tabletype(
-        tables_info.sum_op
-    ) if tables_info.sum_op else None
-    validate_tableinfo_type_matches_actual_tabletype(
-        tables_info.min_op
-    ) if tables_info.min_op else None
-    validate_tableinfo_type_matches_actual_tabletype(
-        tables_info.max_op
-    ) if tables_info.max_op else None
-
-
-def _convert_table_result_to_udf_statements(
-    result: UDFGenTableResult, templates_mapping: dict
-) -> List[str]:
-    return [
-        result.create_query.substitute(**templates_mapping),
-    ]
-
-
-def _get_all_table_results_from_smpc_result(
-    smpc_result: UDFGenSMPCResult,
-) -> List[UDFGenTableResult]:
-    table_results = [smpc_result.template]
-    table_results.append(
-        smpc_result.sum_op_values
-    ) if smpc_result.sum_op_values else None
-    table_results.append(
-        smpc_result.min_op_values
-    ) if smpc_result.min_op_values else None
-    table_results.append(
-        smpc_result.max_op_values
-    ) if smpc_result.max_op_values else None
-    return table_results
-
-
-def _convert_smpc_result_to_udf_statements(
-    result: UDFGenSMPCResult, templates_mapping: dict
-) -> List[str]:
-    table_results = _get_all_table_results_from_smpc_result(result)
-    udf_statements = []
-    for result in table_results:
-        udf_statements.extend(
-            _convert_table_result_to_udf_statements(result, templates_mapping)
-        )
-    return udf_statements
-
-
-def _create_udf_statements(
-    udf_execution_queries: UDFGenExecutionQueries,
-    templates_mapping: dict,
-) -> List[str]:
-    udf_statements = []
-    for result in udf_execution_queries.udf_results:
-        if isinstance(result, UDFGenTableResult):
-            udf_statements.extend(
-                _convert_table_result_to_udf_statements(result, templates_mapping)
-            )
-        elif isinstance(result, UDFGenSMPCResult):
-            udf_statements.extend(
-                _convert_smpc_result_to_udf_statements(result, templates_mapping)
-            )
-        else:
-            raise NotImplementedError
-
-    if udf_execution_queries.udf_definition_query:
-        udf_statements.append(
-            udf_execution_queries.udf_definition_query.substitute(**templates_mapping)
-        )
-    udf_statements.append(
-        udf_execution_queries.udf_select_query.substitute(**templates_mapping)
-    )
-
-    return udf_statements
-
-
-def _convert_udfgen2table_info_result_and_mapping(
-    udfgen_result: UDFGenTableResult,
-    context_id: str,
-    command_id: str,
-    command_subid: int,
-) -> Tuple[TableInfo, Dict[str, str]]:
-    table_name_ = create_table_name(
-        table_type=TableType.NORMAL,
-        node_id=node_config.identifier,
-        context_id=context_id,
-        command_id=command_id,
-        command_subid=str(command_subid),
-    )
-    table_name_tmpl_mapping = {udfgen_result.tablename_placeholder: table_name_}
-    return (
-        TableInfo(
-            name=table_name_,
-            schema_=_convert_udfgen_iotype2table_schema(udfgen_result.table_schema),
-            type_=TableType.NORMAL,
-        ),
-        table_name_tmpl_mapping,
-    )
-
-
-def _convert_udfgen_iotype2table_schema(iotype: List[Tuple[str, DType]]) -> TableSchema:
-    return TableSchema(
-        columns=[ColumnInfo(name=name, dtype=dtype) for name, dtype in iotype]
-    )
-
-
-def _convert_udfgen2smpc_tables_info_result_and_mapping(
-    udfgen_result: UDFGenSMPCResult,
-    context_id: str,
-    command_id: str,
-    command_subid: int,
-) -> Tuple[SMPCTablesInfo, Dict[str, str]]:
-    (
-        template_udf_result,
-        table_names_tmpl_mapping,
-    ) = _convert_udfgen2table_info_result_and_mapping(
-        udfgen_result.template, context_id, command_id, command_subid
-    )
-
-    if udfgen_result.sum_op_values:
-        (sum_op_udf_result, mapping,) = _convert_udfgen2table_info_result_and_mapping(
-            udfgen_result.sum_op_values, context_id, command_id, command_subid + 1
-        )
-        table_names_tmpl_mapping.update(mapping)
-    else:
-        sum_op_udf_result = None
-
-    if udfgen_result.min_op_values:
-        (min_op_udf_result, mapping,) = _convert_udfgen2table_info_result_and_mapping(
-            udfgen_result.min_op_values, context_id, command_id, command_subid + 2
-        )
-        table_names_tmpl_mapping.update(mapping)
-    else:
-        min_op_udf_result = None
-
-    if udfgen_result.max_op_values:
-        (max_op_udf_result, mapping,) = _convert_udfgen2table_info_result_and_mapping(
-            udfgen_result.max_op_values, context_id, command_id, command_subid + 3
-        )
-        table_names_tmpl_mapping.update(mapping)
-    else:
-        max_op_udf_result = None
-
-    result = SMPCTablesInfo(
-        template=template_udf_result,
-        sum_op=sum_op_udf_result,
-        min_op=min_op_udf_result,
-        max_op=max_op_udf_result,
-    )
-    return result, table_names_tmpl_mapping
-
-
-def _convert_udfgen2nodeudf_result_and_mapping(
-    udfgen_result: UDFGenResult,
-    context_id: str,
-    command_id: str,
-    command_subid: int,
-) -> Tuple[NodeUDFDTO, Dict[str, str]]:
-    if isinstance(udfgen_result, UDFGenTableResult):
-        table_info, mapping = _convert_udfgen2table_info_result_and_mapping(
-            udfgen_result, context_id, command_id, command_subid
-        )
-        return NodeTableDTO(value=table_info), mapping
-    elif isinstance(udfgen_result, UDFGenSMPCResult):
-        tables_info, mapping = _convert_udfgen2smpc_tables_info_result_and_mapping(
-            udfgen_result, context_id, command_id, command_subid
-        )
-        return NodeSMPCDTO(value=tables_info), mapping
-    else:
-        raise NotImplementedError
-
-
-def convert_udfgen2nodeudf_results_and_mapping(
-    udf_queries: UDFGenExecutionQueries,
-    context_id: str,
-    command_id: str,
-) -> Tuple[NodeUDFResults, Dict[str, str]]:
-    """
-    Iterates through all the udf generator results, in order to create
-    a table for each one.
-
-    UDFResults are returned together with a mapping of
-    template -> tablename, so it can be used in the udf's declaration to
-    replace the templates with the actual table names.
-
-    Returns
-    -------
-    a UDFResults object containing all the results
-    a dictionary of template (placeholder) tablename to the actual table name.
-    """
-    results = []
-    table_names_tmpl_mapping = {}
-    command_subid = 0
-    for udf_result in udf_queries.udf_results:
-        table, mapping = _convert_udfgen2nodeudf_result_and_mapping(
-            udf_result,
-            context_id,
-            command_id,
-            command_subid,
-        )
-        table_names_tmpl_mapping.update(mapping)
-        results.append(table)
-
-        # Needs to be incremented by 10 because a udf_result could
-        # contain more than one tables. (SMPC for example)
-        command_subid += 10
-
-    udf_results = NodeUDFResults(results=results)
-    return udf_results, table_names_tmpl_mapping
+def _validate_smpctablesinfo_type_matches_actual_tablestype(
+    tables_info: SMPCTablesInfo,
+):
+    _validate_tableinfo_type_matches_actual_tabletype(tables_info.template)
+    if tables_info.sum_op:
+        _validate_tableinfo_type_matches_actual_tabletype(tables_info.sum_op)
+    if tables_info.min_op:
+        _validate_tableinfo_type_matches_actual_tabletype(tables_info.min_op)
+    if tables_info.max_op:
+        _validate_tableinfo_type_matches_actual_tabletype(tables_info.max_op)
 
 
 @sql_injection_guard(
@@ -473,33 +259,118 @@ def _generate_udf_statements(
     use_smpc: bool,
     output_schema,
 ) -> Tuple[List[str], NodeUDFResults]:
+    # Data needed for UDF generation
+    # ------------------------------
+    flowargs, flowkwargs = _convert_nodeudf_to_flow_args(positional_args, keyword_args)
     udf_name = _create_udf_name(func_name, command_id, context_id)
 
-    gen_pos_args, gen_kw_args = _convert_nodeudf2udfgen_args(
-        positional_args, keyword_args
-    )
+    # node_id is needed for table name creation
+    node_id = node_config.identifier
 
-    udf_execution_queries = generate_udf_queries(
+    # min_row_count is necessary when an algorithm needs it in the UDF
+    min_row_count = node_config.privacy.minimum_row_count
+
+    # outputlen is the number of UDF outputs, we need it to create an
+    # equal number of output names before calling the UDF generator
+    outputlen = len(udf.registry[func_name].output_types)
+
+    # A UDF may produce more than one table results, so we create a
+    # list of one or more output table names
+    output_names = _make_output_table_names(outputlen, node_id, context_id, command_id)
+
+    # UDF generation
+    # --------------
+    udfgen = UdfGenerator(
+        udfregistry=udf.registry,
         func_name=func_name,
-        positional_args=gen_pos_args,
-        keyword_args=gen_kw_args,
+        flowargs=flowargs,
+        flowkwargs=flowkwargs,
         smpc_used=use_smpc,
+        request_id=request_id,
         output_schema=output_schema,
+        min_row_count=min_row_count,
+    )
+    udf_definition = udfgen.get_definition(udf_name, output_names)
+    udf_exec_stmt = udfgen.get_exec_stmt(udf_name, output_names)
+    udf_results = udfgen.get_results(output_names)
+
+    # Create list of udf statements
+    udf_statements = [res.create_query for res in udf_results]
+    udf_statements.append(udf_definition)
+    udf_statements.append(udf_exec_stmt)
+
+    # Convert results
+    results = [_convert_result(res) for res in udf_results]
+    results_dto = NodeUDFResults(results=results)
+
+    return udf_statements, results_dto
+
+
+def _make_output_table_names(
+    outputlen: int, node_id: str, context_id: str, command_id: str
+) -> List[str]:
+    return [
+        create_table_name(
+            table_type=TableType.NORMAL,
+            node_id=node_id,
+            context_id=context_id,
+            command_id=command_id,
+            result_id=str(id),
+        )
+        for id in range(outputlen)
+    ]
+
+
+def _convert_result(result: UDFGenResult) -> NodeUDFDTO:
+    if isinstance(result, UDFGenTableResult):
+        return _convert_table_result(result)
+    elif isinstance(result, UDFGenSMPCResult):
+        return _convert_smpc_result(result)
+    raise TypeError(f"Unknown result type {result.__class__}")
+
+
+def _convert_table_result(result: UDFGenTableResult) -> NodeTableDTO:
+    table_info = TableInfo(
+        name=result.table_name,
+        schema_=_convert_result_schema(result.table_schema),
+        type_=TableType.NORMAL,
+    )
+    return NodeTableDTO(value=table_info)
+
+
+def _convert_smpc_result(result: UDFGenSMPCResult) -> NodeSMPCDTO:
+    table_infos = {}
+
+    table_infos["template"] = TableInfo(
+        name=result.template.table_name,
+        schema_=_convert_result_schema(result.template.table_schema),
+        type_=TableType.NORMAL,
     )
 
-    (udf_results, templates_mapping,) = convert_udfgen2nodeudf_results_and_mapping(
-        udf_execution_queries, context_id, command_id
-    )
+    if result.sum_op_values:
+        table_infos["sum_op"] = TableInfo(
+            name=result.sum_op_values.table_name,
+            schema_=_convert_result_schema(result.sum_op_values.table_schema),
+            type_=TableType.NORMAL,
+        )
 
-    # Adding the udf_name and node_identifier to the mapping
-    templates_mapping.update(
-        {
-            "udf_name": udf_name,
-            "node_id": node_config.identifier,
-            "min_row_count": node_config.privacy.minimum_row_count,
-            "request_id": request_id,
-        }
-    )
-    udf_statements = _create_udf_statements(udf_execution_queries, templates_mapping)
+    if result.min_op_values:
+        table_infos["min_op"] = TableInfo(
+            name=result.min_op_values.table_name,
+            schema_=_convert_result_schema(result.min_op_values.table_schema),
+            type_=TableType.NORMAL,
+        )
 
-    return udf_statements, udf_results
+    if result.max_op_values:
+        table_infos["max_op"] = TableInfo(
+            name=result.max_op_values.table_name,
+            schema_=_convert_result_schema(result.max_op_values.table_schema),
+            type_=TableType.NORMAL,
+        )
+
+    return NodeSMPCDTO(value=SMPCTablesInfo(**table_infos))
+
+
+def _convert_result_schema(schema: List[Tuple[str, DType]]) -> TableSchema:
+    columns = [ColumnInfo(name=name, dtype=dtype) for name, dtype in schema]
+    return TableSchema(columns=columns)

--- a/mipengine/node/tasks/views.py
+++ b/mipengine/node/tasks/views.py
@@ -97,7 +97,7 @@ def create_data_model_views(
         create_data_model_view(
             context_id=context_id,
             command_id=command_id,
-            command_sub_id=str(count),
+            result_id=str(count),
             data_model=data_model,
             columns=view_columns,
             filters=filters,
@@ -110,7 +110,7 @@ def create_data_model_views(
 def create_data_model_view(
     context_id: str,
     command_id: str,
-    command_sub_id: str,
+    result_id: str,
     data_model: str,
     columns: List[str],
     filters: dict = None,
@@ -121,7 +121,7 @@ def create_data_model_view(
         node_id=node_config.identifier,
         context_id=context_id,
         command_id=command_id,
-        command_subid=command_sub_id,
+        result_id=result_id,
     )
     columns.insert(0, DATA_TABLE_PRIMARY_KEY)
 

--- a/mipengine/node_tasks_DTOs.py
+++ b/mipengine/node_tasks_DTOs.py
@@ -70,10 +70,8 @@ class TableInfo(ImmutableBaseModel):
 
     @property
     def _tablename_parts(self) -> Tuple[str, str, str, str]:
-        table_type, node_id, context_id, command_id, command_subid = self.name.split(
-            "_"
-        )
-        return node_id, context_id, command_id, command_subid
+        table_type, node_id, context_id, command_id, result_id = self.name.split("_")
+        return node_id, context_id, command_id, result_id
 
     @property
     def node_id(self) -> str:
@@ -91,9 +89,9 @@ class TableInfo(ImmutableBaseModel):
         return command_id
 
     @property
-    def command_subid(self) -> str:
-        _, _, _, command_subid = self._tablename_parts
-        return command_subid
+    def result_id(self) -> str:
+        _, _, _, result_id = self._tablename_parts
+        return result_id
 
     @property
     def name_without_node_id(self) -> str:
@@ -104,7 +102,7 @@ class TableInfo(ImmutableBaseModel):
             + "_"
             + self.command_id
             + "_"
-            + self.command_subid
+            + self.result_id
         )
 
 

--- a/mipengine/udfgen/__init__.py
+++ b/mipengine/udfgen/__init__.py
@@ -11,21 +11,23 @@ from mipengine.udfgen.iotypes import tensor
 from mipengine.udfgen.iotypes import transfer
 from mipengine.udfgen.iotypes import udf_logger
 from mipengine.udfgen.smpc import secure_transfer
-from mipengine.udfgen.udfgenerator import generate_udf_queries
+from mipengine.udfgen.udfgenerator import FlowUdfArg
+from mipengine.udfgen.udfgenerator import UdfGenerator
 
 __all__ = [
+    "literal",
+    "make_unique_func_name",
+    "merge_tensor",
+    "merge_transfer",
+    "relation",
+    "secure_transfer",
+    "state",
+    "tensor",
+    "transfer",
     "udf",
     "udf_logger",
-    "tensor",
-    "relation",
-    "merge_tensor",
-    "literal",
-    "transfer",
-    "merge_transfer",
-    "state",
-    "secure_transfer",
-    "generate_udf_queries",
-    "make_unique_func_name",
+    "FlowUdfArg",
+    "UdfGenerator",
     "DEFERRED",
     "MIN_ROW_COUNT",
 ]

--- a/mipengine/udfgen/decorator.py
+++ b/mipengine/udfgen/decorator.py
@@ -1,4 +1,5 @@
 import ast
+from collections import defaultdict
 from typing import List
 
 from mipengine.udfgen.ast import Signature
@@ -15,8 +16,13 @@ from mipengine.udfgen.iotypes import TensorType
 from mipengine.udfgen.iotypes import UDFLoggerType
 
 
+class UdfRegistry(defaultdict):
+    def __missing__(self, funcname):
+        raise UDFBadCall(f"The function {funcname} cannot be found in udf registry.")
+
+
 class UDFDecorator:
-    registry = {}
+    registry = UdfRegistry()
 
     def __call__(self, **kwargs):
         def decorator(func):
@@ -155,3 +161,8 @@ def validate_udf_table_input_types(table_input_types):
 class UDFBadDefinition(Exception):
     """Raised when an error is detected in the definition of a udf decorated
     function. These checks are made as soon as the function is defined."""
+
+
+class UDFBadCall(Exception):
+    """Raised when something is wrong with the arguments passed to the udf
+    generator."""

--- a/mipengine/udfgen/iotypes.py
+++ b/mipengine/udfgen/iotypes.py
@@ -7,7 +7,6 @@ from mipengine.udfgen.helpers import iotype_to_sql_schema
 from mipengine.udfgen.helpers import recursive_repr
 
 LN = "\n"
-MAIN_TABLE_PLACEHOLDER = "main_output_table_name"
 ROWID = "row_id"
 DEFERRED = "deferred"
 
@@ -245,7 +244,7 @@ class TransferType(DictType, InputType, LoopbackOutputType):
 
     def get_secondary_return_stmt_template(self, tablename_placeholder) -> str:
         return (
-            '_conn.execute(f"INSERT INTO $'
+            '_conn.execute(f"INSERT INTO '
             + tablename_placeholder
             + " VALUES ('{{json.dumps({return_name})}}');\")"
         )
@@ -299,7 +298,7 @@ class StateType(DictType, InputType, LoopbackOutputType):
 
     def get_secondary_return_stmt_template(self, tablename_placeholder) -> str:
         return (
-            '_conn.execute(f"INSERT INTO $'
+            '_conn.execute(f"INSERT INTO '
             + tablename_placeholder
             + " VALUES ('{{pickle.dumps({return_name}).hex()}}');\")"
         )
@@ -329,8 +328,9 @@ class UDFLoggerArg(UDFArgument):
     type = UDFLoggerType()
     udf_name: str
 
-    def __init__(self, udf_name):
+    def __init__(self, udf_name="", request_id=""):
         self.udf_name = udf_name
+        self.request_id = request_id
 
 
 class PlaceholderArg(UDFArgument):

--- a/mipengine/udfgen/typeinference.py
+++ b/mipengine/udfgen/typeinference.py
@@ -1,0 +1,90 @@
+from typing import Dict
+from typing import TypeVar
+from typing import Union
+
+from mipengine.udfgen.decorator import UDFBadCall
+from mipengine.udfgen.helpers import compose_mappings
+from mipengine.udfgen.helpers import mapping_inverse
+from mipengine.udfgen.helpers import merge_mappings_consistently
+from mipengine.udfgen.iotypes import ParametrizedType
+from mipengine.udfgen.iotypes import TableType
+
+KnownTypeParams = Union[type, int]
+UnknownTypeParams = TypeVar
+TypeParamsInference = Dict[UnknownTypeParams, KnownTypeParams]
+
+
+def infer_output_type(
+    passed_input_types: Dict[str, ParametrizedType],
+    declared_input_types: Dict[str, ParametrizedType],
+    declared_output_type: ParametrizedType,
+) -> ParametrizedType:
+    verify_declared_and_passed_param_types_match(
+        declared_input_types, passed_input_types
+    )
+
+    inferred_input_typeparams = infer_unknown_input_typeparams(
+        declared_input_types,
+        passed_input_types,
+    )
+    known_output_typeparams = dict(**declared_output_type.known_typeparams)
+    inferred_output_typeparams = compose_mappings(
+        declared_output_type.unknown_typeparams,
+        inferred_input_typeparams,
+    )
+    known_output_typeparams.update(inferred_output_typeparams)
+    inferred_output_type = type(declared_output_type)(**known_output_typeparams)
+    return inferred_output_type
+
+
+def infer_unknown_input_typeparams(
+    declared_input_types: "Dict[str, ParametrizedType]",
+    passed_input_types: Dict[str, ParametrizedType],
+) -> TypeParamsInference:
+    typeparams_inference_mappings = [
+        map_unknown_to_known_typeparams(
+            input_type.unknown_typeparams,
+            passed_input_types[name].known_typeparams,
+        )
+        for name, input_type in declared_input_types.items()
+        if input_type.is_generic
+    ]
+    distinct_inferred_typeparams = merge_mappings_consistently(
+        typeparams_inference_mappings
+    )
+    return distinct_inferred_typeparams
+
+
+def map_unknown_to_known_typeparams(
+    unknown_params: Dict[str, UnknownTypeParams],
+    known_params: Dict[str, KnownTypeParams],
+) -> TypeParamsInference:
+    return compose_mappings(mapping_inverse(unknown_params), known_params)
+
+
+def verify_declared_and_passed_param_types_match(
+    declared_types: Dict[str, TableType],
+    passed_types: Dict[str, TableType],
+) -> None:
+    passed_param_args = {
+        name: type
+        for name, type in passed_types.items()
+        if isinstance(type, ParametrizedType)
+    }
+    for argname, type in passed_param_args.items():
+        known_params = declared_types[argname].known_typeparams
+        verify_declared_typeparams_match_passed_type(known_params, type)
+
+
+def verify_declared_typeparams_match_passed_type(
+    known_typeparams: Dict[str, KnownTypeParams],
+    passed_type: ParametrizedType,
+) -> None:
+    for name, param in known_typeparams.items():
+        if not hasattr(passed_type, name):
+            raise UDFBadCall(f"{passed_type} has no typeparam {name}.")
+        if getattr(passed_type, name) != param:
+            raise UDFBadCall(
+                "InputType's known typeparams do not match typeparams passed "
+                f"in {passed_type}: {param}, {getattr(passed_type, name)}."
+            )

--- a/mipengine/udfgen/udfgen_DTOs.py
+++ b/mipengine/udfgen/udfgen_DTOs.py
@@ -1,4 +1,3 @@
-from string import Template
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -8,38 +7,16 @@ from pydantic import BaseModel
 from mipengine import DType
 
 
-class UDFGenBaseModel(BaseModel):
+class UDFGenResult(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         allow_mutation = False
 
 
-class UDFGenResult(UDFGenBaseModel):
-    pass
-
-
 class UDFGenTableResult(UDFGenResult):
-    tablename_placeholder: str
+    table_name: str
     table_schema: List[Tuple[str, DType]]
-    create_query: Template
-
-    def __eq__(self, other):
-        if self.tablename_placeholder != other.tablename_placeholder:
-            return False
-        if self.table_schema != other.table_schema:
-            return False
-        if self.create_query.template != other.create_query.template:
-            return False
-        return True
-
-    def __repr__(self):
-        return (
-            f"UDFGenTableResult("
-            f"{self.tablename_placeholder=}, "
-            f"{self.table_schema=}, "
-            f"{self.create_query.template=}"
-            f")"
-        )
+    create_query: str
 
 
 class UDFGenSMPCResult(UDFGenResult):
@@ -48,41 +25,13 @@ class UDFGenSMPCResult(UDFGenResult):
     min_op_values: Optional[UDFGenTableResult] = None
     max_op_values: Optional[UDFGenTableResult] = None
 
-    def __eq__(self, other):
-        if self.template != other.template:
-            return False
-        if self.sum_op_values != other.sum_op_values:
-            return False
-        if self.min_op_values != other.min_op_values:
-            return False
-        if self.max_op_values != other.max_op_values:
-            return False
-        return True
-
-    def __repr__(self):
-        return (
-            f"UDFGenSMPCResult("
-            f"template={self.template}, "
-            f"sum_op_values={self.sum_op_values}, "
-            f"min_op_values={self.min_op_values}, "
-            f"max_op_values={self.max_op_values}, "
-            f")"
-        )
-
-
-class UDFGenExecutionQueries(UDFGenBaseModel):
-    udf_results: List[UDFGenResult]
-    udf_definition_query: Optional[Template] = None
-    udf_select_query: Template
-
-    def __repr__(self):
-        udf_definition_query_str = "None"
-        if self.udf_definition_query:
-            udf_definition_query_str = self.udf_definition_query.template
-        return (
-            f"UDFExecutionQueries("
-            f"udf_results={self.udf_results}, "
-            f"udf_definition_query='{udf_definition_query_str}', "
-            f"udf_select_query='{self.udf_select_query.template}'"
-            f")"
-        )
+    @property
+    def create_query(self):
+        queries = [self.template.create_query]
+        if self.sum_op_values is not None:
+            queries.append(self.sum_op_values.create_query)
+        if self.min_op_values is not None:
+            queries.append(self.min_op_values.create_query)
+        if self.max_op_values is not None:
+            queries.append(self.max_op_values.create_query)
+        return "".join(queries)

--- a/mipengine/udfgen/udfgenerator.py
+++ b/mipengine/udfgen/udfgenerator.py
@@ -987,7 +987,11 @@ class UdfResultBuilder:
         )
 
 
-# ~~~~~~~~~~~~~~ SQL special queries ~~~~~~~~~~~~~~ #
+# TODO Everything below this point is non functional due to changes brought
+# by work on https://team-1617704806227.atlassian.net/browse/MIP-756
+# This is a temporary. The same functionality will be implemented using
+# a different API soon.
+# This is described in https://team-1617704806227.atlassian.net/browse/MIP-757
 def get_create_dummy_encoded_design_matrix_execution_queries(keyword_args):
     dm_table = get_dummy_encoded_design_matrix_table(keyword_args)
     udf_select = get_dummy_encoded_design_matrix_select_stmt(dm_table)

--- a/tests/algorithm_validation_tests/test_algorithm_executor.py
+++ b/tests/algorithm_validation_tests/test_algorithm_executor.py
@@ -145,6 +145,11 @@ def input_subset_of_nodes_has_sufficient_data():
     return request
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_exec_algorithm_removing_nodes_after_create_data_model_views(
     input_subset_of_nodes_has_sufficient_data,
 ):

--- a/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_linearregression_cv_validation.py
@@ -17,6 +17,13 @@ import scipy.stats as st
 from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "linear_regression_cv"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/algorithm_validation_tests/test_linearregression_validation.py
+++ b/tests/algorithm_validation_tests/test_linearregression_validation.py
@@ -7,6 +7,13 @@ from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import assert_allclose
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "linear_regression"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_cv_validation.py
@@ -7,6 +7,13 @@ import scipy.stats as st
 from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "logistic_regression_cv"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/algorithm_validation_tests/test_logisticregression_validation.py
+++ b/tests/algorithm_validation_tests/test_logisticregression_validation.py
@@ -8,6 +8,13 @@ from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import assert_allclose
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "logistic_regression"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/prod_env_tests/test_linearregression_cv_validation.py
+++ b/tests/prod_env_tests/test_linearregression_cv_validation.py
@@ -17,6 +17,13 @@ import scipy.stats as st
 from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "linear_regression_cv"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/prod_env_tests/test_linearregression_validation.py
+++ b/tests/prod_env_tests/test_linearregression_validation.py
@@ -7,6 +7,13 @@ from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import assert_allclose
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "linear_regression"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/prod_env_tests/test_logisticregression_cv_validation.py
+++ b/tests/prod_env_tests/test_logisticregression_cv_validation.py
@@ -7,6 +7,13 @@ import scipy.stats as st
 from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "logistic_regression_cv"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/prod_env_tests/test_logisticregression_validation.py
+++ b/tests/prod_env_tests/test_logisticregression_validation.py
@@ -8,6 +8,13 @@ from tests.algorithm_validation_tests.helpers import algorithm_request
 from tests.algorithm_validation_tests.helpers import assert_allclose
 from tests.algorithm_validation_tests.helpers import get_test_params
 
+pytest.skip(
+    allow_module_level=True,
+    msg="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757",
+)
+
 algorithm_name = "logistic_regression"
 
 expected_file = Path(__file__).parent / "expected" / f"{algorithm_name}_expected.json"

--- a/tests/standalone_tests/test_cleanup_after_algorithm_execution.py
+++ b/tests/standalone_tests/test_cleanup_after_algorithm_execution.py
@@ -181,7 +181,7 @@ def algorithm_request_dto(datasets):
             ],
             y=["alzheimerbroadcategory"],
         ),
-        parameters={"positive_class": "AD", "positive_class": "CN"},
+        parameters={"positive_class": "AD"},
     )
 
 
@@ -338,6 +338,11 @@ def db_cursors(
     }
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 @pytest.mark.slow
 @pytest.mark.very_slow
 def test_synchronous_cleanup(
@@ -466,6 +471,11 @@ def test_asynchronous_cleanup(
     assert True
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 @pytest.mark.slow
 @pytest.mark.very_slow
 def test_cleanup_triggered_by_release_timelimit(
@@ -533,6 +543,11 @@ def test_cleanup_triggered_by_release_timelimit(
     assert True
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 @pytest.mark.slow
 @pytest.mark.very_slow
 def test_cleanup_after_rabbitmq_restart(
@@ -620,6 +635,11 @@ def test_cleanup_after_rabbitmq_restart(
     assert True
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 @pytest.mark.slow
 @pytest.mark.very_slow
 def test_cleanup_after_node_service_restart(

--- a/tests/standalone_tests/test_create_table_name.py
+++ b/tests/standalone_tests/test_create_table_name.py
@@ -12,7 +12,7 @@ def test_create_table_name():
         node_id="nodeid",
         context_id="contextid",
         command_id="commandid",
-        command_subid="commandsubid",
+        result_id="commandsubid",
     )
 
     tablename_obj = TableInfo(
@@ -23,7 +23,7 @@ def test_create_table_name():
     assert tablename_obj.node_id == "nodeid"
     assert tablename_obj.context_id == "contextid"
     assert tablename_obj.command_id == "commandid"
-    assert tablename_obj.command_subid == "commandsubid"
+    assert tablename_obj.result_id == "commandsubid"
 
 
 def test_create_table_name_with_bad_table_type():
@@ -33,7 +33,7 @@ def test_create_table_name_with_bad_table_type():
             node_id="nodeid",
             context_id="contextid",
             command_id="commandid",
-            command_subid="commandsubid",
+            result_id="commandsubid",
         )
 
     assert "Table type is not acceptable: " in str(exc)
@@ -95,11 +95,11 @@ def get_test_create_table_name_with_bad_parameters_cases():
 
 
 @pytest.mark.parametrize(
-    "table_type, node_id, context_id, command_id, command_subid",
+    "table_type, node_id, context_id, command_id, result_id",
     get_test_create_table_name_with_bad_parameters_cases(),
 )
 def test_create_table_with_bad_parameters(
-    table_type, node_id, context_id, command_id, command_subid
+    table_type, node_id, context_id, command_id, result_id
 ):
     with pytest.raises(ValueError) as exc:
         create_table_name(
@@ -107,7 +107,7 @@ def test_create_table_with_bad_parameters(
             node_id=node_id,
             context_id=context_id,
             command_id=command_id,
-            command_subid=command_subid,
+            result_id=result_id,
         )
 
     assert "is not alphanumeric" in str(exc)

--- a/tests/standalone_tests/test_node_tasks_dtos.py
+++ b/tests/standalone_tests/test_node_tasks_dtos.py
@@ -108,7 +108,7 @@ def test_table_schema_immutable():
 @pytest.fixture
 def table_info_proper_type():
     return TableInfo(
-        name="test",
+        name="a_b_c_d_e",
         schema_=TableSchema(
             columns=[
                 ColumnInfo(name="layla", dtype=DType.FLOAT),
@@ -159,7 +159,7 @@ def test_table_info_error():
 
 def test_table_info_immutable():
     info = TableInfo(
-        name="name",
+        name="a_b_c_d_e",
         schema_=TableSchema(
             columns=[
                 ColumnInfo(name="layla", dtype=DType.FLOAT),
@@ -170,6 +170,29 @@ def test_table_info_immutable():
     )
     with pytest.raises(TypeError):
         info.name = "newname"
+
+
+def test_table_info__valid_name():
+    info = TableInfo(
+        name="NORMAL_nodeid_ctxid_cmdid_resid",
+        schema_=TableSchema(columns=[]),
+        type_=TableType.NORMAL,
+    )
+    assert info.node_id == "nodeid"
+    assert info.context_id == "ctxid"
+    assert info.command_id == "cmdid"
+    assert info.result_id == "resid"
+    assert info.name_without_node_id == "NORMAL_ctxid_cmdid_resid"
+
+
+def test_table_info__invalid_name():
+    info = TableInfo(
+        name="name",
+        schema_=TableSchema(columns=[]),
+        type_=TableType.NORMAL,
+    )
+    with pytest.raises(ValueError):
+        info.node_id
 
 
 def test_table_data_error():
@@ -206,7 +229,7 @@ def test_udf_dto_instantiation():
 def test_udf_dtos_immutable():
     argument = NodeTableDTO(
         value=TableInfo(
-            name="whatever",
+            name="a_b_c_d_e",
             schema_=TableSchema(columns=[ColumnInfo(name="test", dtype=DType.INT)]),
             type_=TableType.NORMAL,
         )
@@ -223,7 +246,7 @@ def test_udf_dtos_immutable():
     argument = NodeSMPCDTO(
         value=SMPCTablesInfo(
             template=TableInfo(
-                name="whatever",
+                name="a_b_c_d_e",
                 schema_=TableSchema(columns=[ColumnInfo(name="test", dtype=DType.INT)]),
                 type_=TableType.NORMAL,
             )
@@ -237,7 +260,7 @@ def test_udf_dtos_immutable():
 def test_udf_dtos_correct_type():
     argument = NodeTableDTO(
         value=TableInfo(
-            name="whatever",
+            name="a_b_c_d_e",
             schema_=TableSchema(columns=[ColumnInfo(name="test", dtype=DType.INT)]),
             type_=TableType.NORMAL,
         )
@@ -250,7 +273,7 @@ def test_udf_dtos_correct_type():
     argument = NodeSMPCDTO(
         value=SMPCTablesInfo(
             template=TableInfo(
-                name="whatever",
+                name="a_b_c_d_e",
                 schema_=TableSchema(columns=[ColumnInfo(name="test", dtype=DType.INT)]),
                 type_=TableType.NORMAL,
             )
@@ -264,7 +287,7 @@ def get_udf_args_cases():
         [
             NodeTableDTO(
                 value=TableInfo(
-                    name="whatever",
+                    name="a_b_c_d_e",
                     schema_=TableSchema(
                         columns=[ColumnInfo(name="test", dtype=DType.INT)]
                     ),
@@ -275,30 +298,30 @@ def get_udf_args_cases():
         [
             NodeTableDTO(
                 value=TableInfo(
-                    name="whatever",
+                    name="a_b_c_d_e",
                     schema_=TableSchema(
                         columns=[ColumnInfo(name="test", dtype=DType.INT)]
                     ),
                     type_=TableType.NORMAL,
                 )
             ),
-            NodeLiteralDTO(value="whatever"),
+            NodeLiteralDTO(value="a_b_c_d_e"),
         ],
         [
             NodeTableDTO(
                 value=TableInfo(
-                    name="whatever",
+                    name="a_b_c_d_e",
                     schema_=TableSchema(
                         columns=[ColumnInfo(name="test", dtype=DType.INT)]
                     ),
                     type_=TableType.NORMAL,
                 )
             ),
-            NodeLiteralDTO(value="whatever"),
+            NodeLiteralDTO(value="a_b_c_d_e"),
             NodeSMPCDTO(
                 value=SMPCTablesInfo(
                     template=TableInfo(
-                        name="whatever",
+                        name="a_b_c_d_e",
                         schema_=TableSchema(
                             columns=[ColumnInfo(name="test", dtype=DType.INT)]
                         ),
@@ -336,7 +359,7 @@ def get_udf_results_cases():
             results=[
                 NodeTableDTO(
                     value=TableInfo(
-                        name="whatever",
+                        name="a_b_c_d_e",
                         schema_=TableSchema(
                             columns=[ColumnInfo(name="test", dtype=DType.INT)]
                         ),
@@ -350,7 +373,7 @@ def get_udf_results_cases():
                 NodeSMPCDTO(
                     value=SMPCTablesInfo(
                         template=TableInfo(
-                            name="whatever",
+                            name="a_b_c_d_e",
                             schema_=TableSchema(
                                 columns=[ColumnInfo(name="test", dtype=DType.INT)]
                             ),
@@ -364,7 +387,7 @@ def get_udf_results_cases():
             results=[
                 NodeTableDTO(
                     value=TableInfo(
-                        name="whatever",
+                        name="a_b_c_d_e",
                         schema_=TableSchema(
                             columns=[ColumnInfo(name="test", dtype=DType.INT)]
                         ),
@@ -374,7 +397,7 @@ def get_udf_results_cases():
                 NodeSMPCDTO(
                     value=SMPCTablesInfo(
                         template=TableInfo(
-                            name="whatever",
+                            name="a_b_c_d_e",
                             schema_=TableSchema(
                                 columns=[ColumnInfo(name="test", dtype=DType.INT)]
                             ),

--- a/tests/standalone_tests/test_single_local_node_algorithm_execution.py
+++ b/tests/standalone_tests/test_single_local_node_algorithm_execution.py
@@ -210,7 +210,7 @@ def algorithm_request_case_2(datasets):
             ],
             y=["alzheimerbroadcategory"],
         ),
-        parameters={"positive_class": "AD", "positive_class": "CN"},
+        parameters={"positive_class": "AD"},
     )
     return (algorithm_name, algo_request_dto)
 
@@ -438,6 +438,11 @@ def engine_case_2(
     )
 
 
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "algorithm,engine",

--- a/tests/standalone_tests/udfgen/conftest.py
+++ b/tests/standalone_tests/udfgen/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-from mipengine.udfgen import udf
-
-
-@pytest.fixture(autouse=True)
-def clear_udf_registry():
-    yield
-    udf.registry = {}

--- a/tests/standalone_tests/udfgen/test_tensor_ops.py
+++ b/tests/standalone_tests/udfgen/test_tensor_ops.py
@@ -3,6 +3,8 @@ from string import Template
 
 import pytest
 
+pytest.skip(allow_module_level=True, msg="The tensor_ops module is deprecated.")
+
 from mipengine.datatypes import DType
 from mipengine.node_tasks_DTOs import ColumnInfo
 from mipengine.node_tasks_DTOs import TableInfo
@@ -16,8 +18,6 @@ from mipengine.udfgen.tensor_ops import get_matrix_transpose_template
 from mipengine.udfgen.tensor_ops import get_tensor_binary_op_template
 from mipengine.udfgen.udfgen_DTOs import UDFGenTableResult
 from tests.standalone_tests.udfgen.test_udfgenerator import TestUDFGenBase
-
-pytest.skip(allow_module_level=True, msg="The tensor_ops module is deprecated.")
 
 
 class TestUDFGen_SQLTensorMultOut1D(TestUDFGenBase):

--- a/tests/standalone_tests/udfgen/test_udfgenerator.py
+++ b/tests/standalone_tests/udfgen/test_udfgenerator.py
@@ -4710,7 +4710,11 @@ class N:
     ...
 
 
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_get_create_design_matrix_select_only_numerical():
     enums = {}
     numerical_vars = ["n1", "n2"]
@@ -4735,7 +4739,11 @@ FROM
     assert result.udf_select_query.template == expected
 
 
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_get_create_design_matrix_select_only_categorical():
     enums = {
         "c1": [{"code": "l1", "dummy": "c1__1"}, {"code": "l2", "dummy": "c1__2"}],
@@ -4762,7 +4770,11 @@ FROM
     assert result.udf_select_query.template == expected
 
 
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_get_create_design_matrix_select_no_intercept():
     enums = {
         "c1": [{"code": "l1", "dummy": "c1__1"}, {"code": "l2", "dummy": "c1__2"}],
@@ -4788,7 +4800,11 @@ FROM
     assert result.udf_select_query.template == expected
 
 
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_get_create_design_matrix_select_full():
     enums = {
         "c1": [{"code": "l1", "dummy": "c1__1"}, {"code": "l2", "dummy": "c1__2"}],
@@ -4825,7 +4841,11 @@ FROM
     assert result.udf_select_query.template == expected
 
 
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="DummyEncoder is temporarily disabled due to changes in "
+    "the UDF generator API. Will be re-implemented in ticket "
+    "https://team-1617704806227.atlassian.net/browse/MIP-757"
+)
 def test_get_create_design_matrix_create_query():
     enums = {
         "c1": [{"code": "l1", "dummy": "c1__1"}, {"code": "l2", "dummy": "c1__2"}],


### PR DESCRIPTION
- Change UDF generator API (see 3e10bd7a4f03f5f677513f374fa28bca2bf57fd1 for details) ([756](https://team-1617704806227.atlassian.net/browse/MIP-756))
- Rewrite parts of `mipengine/node/tasks/udfs.py` to comply with the new API ([756](https://team-1617704806227.atlassian.net/browse/MIP-756))
- Reorganize loose functions in `udfgenerator.py` into classes
- Skip tests using `DummyEncoder` (see 441571da8999d80a2f0b8f5213ba80016a4e0dfc for details)
- Small fix in `preprocessing.FormulaTransformer`