### PR TITLE
Fix/mip 732/monet db memory error handling

### DIFF
--- a/.github/workflows/prod_env_tests.yml
+++ b/.github/workflows/prod_env_tests.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 3.6.3
+          version: 3.9.1
         id: install
 
       - name: Taint Nodes
@@ -195,8 +195,11 @@ jobs:
       - name: Copy prod_env_tests values.yaml
         run: cp -r tests/prod_env_tests/deployment_configs/kubernetes_values.yaml kubernetes/values.yaml
 
+      - name: Print Helm Templates
+        run: helm template kubernetes/
+
       - name: Deploy Helm
-        run: helm install mipengine kubernetes/
+        run: helm install mipengine kubernetes/ --debug
 
       - name: Wait for MONETDB container to start
         uses: jakejarvis/wait-action@master

--- a/kubernetes/templates/mipengine-controller.yaml
+++ b/kubernetes/templates/mipengine-controller.yaml
@@ -82,8 +82,8 @@ spec:
         ports:
           - containerPort: 6379
         env:
-          - name: REDIS_REPLICATION_MODE
-            value: "master"
+        - name: REDIS_REPLICATION_MODE
+          value: "master"
 
       - name: smpc-coordinator
         image: {{ .Values.smpc.image }}

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -28,12 +28,16 @@ spec:
         image: {{ .Values.mipengine_images.repository }}/mipenginedb:{{ .Values.mipengine_images.version }}
         resources:
           limits:
-            memory: {{ quote .Values.db.max_memory }}
+            memory: "{{ .Values.db.max_memory }}Mi"
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}
         - name: MONETDB_NCLIENTS
           value: {{ mul .Values.max_concurrent_experiments .Values.localnodes | quote }}
+        - name: SOFT_RESTART_MEMORY_LIMIT
+          value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
+        - name: HARD_RESTART_MEMORY_LIMIT
+          value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_hard_memory_limit) 100 | quote }}
         ports:
           - containerPort: 50000
         volumeMounts:

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -40,10 +40,15 @@ spec:
         image: {{ .Values.mipengine_images.repository }}/mipenginedb:{{ .Values.mipengine_images.version }}
         resources:
           limits:
-            memory: {{ quote .Values.db.max_memory }}
+            memory: "{{ .Values.db.max_memory }}Mi"
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}
+        - name: SOFT_RESTART_MEMORY_LIMIT
+          value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
+        - name: HARD_RESTART_MEMORY_LIMIT
+          value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_hard_memory_limit) 100 | quote }}
+
         ports:
           - containerPort: 50000
         volumeMounts:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -12,7 +12,9 @@ max_concurrent_experiments: 32
 db:
   storage_location: /opt/mipengine/db
   csvs_location: /opt/mipengine/csvs
-  max_memory: 1024Mi    # k8s memory limit
+  max_memory: 1024    # k8s memory limit in megabytes
+  percentage_soft_memory_limit: 65
+  percentage_hard_memory_limit: 85
 
 controller:
   node_landscape_aggregator_update_interval: 30

--- a/mipengine/node/monetdb_interface/monet_db_facade.py
+++ b/mipengine/node/monetdb_interface/monet_db_facade.py
@@ -1,168 +1,270 @@
 from contextlib import contextmanager
+from functools import wraps
+from typing import Any
 from typing import List
+from typing import Optional
 
 import pymonetdb
 from eventlet.greenthread import sleep
 from eventlet.lock import Semaphore
+from pydantic import BaseModel
+from pymonetdb import ProgrammingError
 
 from mipengine.node import config as node_config
 from mipengine.node import node_logger as logging
-from mipengine.singleton import Singleton
 
-INTEGRITY_ERROR_RETRY_INTERVAL = 1
-CONN_RECOVERY_MAX_ATTEMPTS = 10
-CONN_RECOVERY_ERROR_RETRY = 0.2
-
+UDF_EXECUTION_QUERY_PREFIX = "INSERT INTO"
 query_execution_lock = Semaphore()
 udf_execution_lock = Semaphore()
 
 
-def db_execute_and_fetchall(query: str, parameters=None, many=False) -> List:
-    return _execute_queries_with_connection_handling(
-        func=_execute_and_fetchall,
-        query=query,
-        parameters=parameters,
-        many=many,
+class _DBExecutionDTO(BaseModel):
+    query: str
+    parameters: Optional[List[Any]]
+    timeout: Optional[int]
+
+    class Config:
+        allow_mutation = False
+
+
+def db_execute_and_fetchall(query: str, parameters=None) -> List:
+    query_execution_timeout = node_config.celery.tasks_timeout
+    db_execution_dto = _DBExecutionDTO(
+        query=query, parameters=parameters, timeout=query_execution_timeout
     )
+    return _execute_and_fetchall(db_execution_dto=db_execution_dto)
 
 
-def db_execute(query: str, parameters=None, many=False) -> List:
-    return _execute_queries_with_connection_handling(
-        func=_execute, query=query, parameters=parameters, many=many
+# TODO:https://team-1617704806227.atlassian.net/browse/MIP-763
+def db_execute(query: str, parameters=None):
+    if query.startswith(UDF_EXECUTION_QUERY_PREFIX):
+        _db_execute_udf(query, parameters)
+    else:
+        _db_execute_query(query, parameters)
+
+
+def _db_execute_query(query: str, parameters=None):
+    query_execution_timeout = node_config.celery.run_udf_task_timeout
+    db_execution_dto = _DBExecutionDTO(
+        query=query, parameters=parameters, timeout=query_execution_timeout
     )
+    _execute(db_execution_dto=db_execution_dto, lock=query_execution_lock)
 
 
-class _DBExecutionDTO:
-    def __init__(self, query, parameters=None, many=False):
-        self.query = query
-        self.parameters = parameters
-        self.many = many
+def _db_execute_udf(query: str, parameters=None):
+    # Check if there is only one query
+    split_queries = [query for query in query.strip().split(";") if query]
+    if len(split_queries) > 1:
+        raise ValueError(f"UDF execution query: {query} should contain only one query.")
 
-
-class _LockDTO:
-    def __init__(self, lock, timeout):
-        self.lock = lock
-        self.timeout = timeout
-
-
-class _MonetDBConnectionPool(metaclass=Singleton):
-    """
-    MonetDBConnectionPool is a Singleton class.
-
-    We use pseudo-multithreading(eventlet greenlets),
-    we provide a connection pool to support concurrent query execution.
-    """
-
-    def __init__(self):
-        self._connection_pool = []
-
-    def create_connection(self):
-        return pymonetdb.connect(
-            hostname=node_config.monetdb.ip,
-            port=node_config.monetdb.port,
-            username=node_config.monetdb.username,
-            password=node_config.monetdb.password,
-            database=node_config.monetdb.database,
-        )
-
-    def get_connection(self):
-        """
-        We use pseudo-multithreading (eventlet greenlets) by committing before a query we refresh the state
-        of the connection so that it sees changes from other connections.
-        https://stackoverflow.com/questions/9305669/mysql-python-connection-does-not-see-changes-to-database-made
-        """
-        if not self._connection_pool:
-            connection = self.create_connection()
-        else:
-            connection = self._connection_pool.pop()
-        connection.commit()
-        return connection
-
-    def release_connection(self, connection):
-        connection.commit()
-        self._connection_pool.append(connection)
+    udf_execution_timeout = node_config.celery.run_udf_task_timeout
+    db_execution_dto = _DBExecutionDTO(
+        query=query, parameters=parameters, timeout=udf_execution_timeout
+    )
+    _execute(db_execution_dto=db_execution_dto, lock=udf_execution_lock)
 
 
 @contextmanager
-def _cursor(_connection):
-    cur = _connection.cursor()
-    yield cur
-    cur.close()
+def _connection():
+    conn = pymonetdb.connect(
+        hostname=node_config.monetdb.ip,
+        port=node_config.monetdb.port,
+        username=node_config.monetdb.username,
+        password=node_config.monetdb.password,
+        database=node_config.monetdb.database,
+    )
+    yield conn
+    conn.close()
 
 
-def _execute_and_commit(conn, db_execution_dto):
-    with _cursor(conn) as cur:
-        cur.executemany(
-            db_execution_dto.query, db_execution_dto.parameters
-        ) if db_execution_dto.many else cur.execute(
-            db_execution_dto.query, db_execution_dto.parameters
-        )
-    conn.commit()
+@contextmanager
+def _cursor(commit=False):
+    with _connection() as conn:
+        cur = conn.cursor()
+        yield cur
+        cur.close()
+        if commit:
+            conn.commit()
 
 
 @contextmanager
 def _lock(query_lock, timeout):
     acquired = query_lock.acquire(timeout=timeout)
     if not acquired:
-        raise TimeoutError()
+        raise TimeoutError("Could not acquire the lock in the designed timeout.")
     try:
         yield
     finally:
         query_lock.release()
 
 
-def _execute_queries_with_connection_handling(func, *args, **kwargs):
+def _get_table_name_on_query(query: str, query_prefix: str):
+    # We need to extract the table name from the query
+    string_before_table_name_pos = query.find(query_prefix)
+    table_name, *_ = query[string_before_table_name_pos + len(query_prefix) :].split()
+    return table_name
+
+
+def _create_idempotent_insert_into_query(query):
     """
-    On the query execution we need to handle the 'OSError' and 'BrokenPipeError' exception.
-    On both cases we try for x amount of times to recover the connection with the database.
+    In order for an insert query to be idempotent,
+    we need to delete all the existing values of the table,
+    before inserting the new values.'
     """
-    conn = None
-    for tries in range(CONN_RECOVERY_MAX_ATTEMPTS):
-
-        try:
-            conn = _MonetDBConnectionPool().get_connection()
-            result = func(*args, **kwargs, conn=conn)
-            _MonetDBConnectionPool().release_connection(conn)
-            return result
-        except (BrokenPipeError, OSError) as exc:
-            logger = logging.get_logger()
-            logger.warning(
-                f"Trying to recover the connection with the database. Exception type: '{type(exc)}', exc: '{exc}'"
-            )
-            sleep(tries * CONN_RECOVERY_ERROR_RETRY)
-        except Exception as exc:
-            if conn:
-                conn.rollback()
-                _MonetDBConnectionPool().release_connection(conn)
-            raise exc
-    else:
-        raise ConnectionError("Failed to connect with the database.")
+    if UDF_EXECUTION_QUERY_PREFIX in query:
+        table_name = _get_table_name_on_query(query, UDF_EXECUTION_QUERY_PREFIX)
+        return f"DELETE FROM {table_name};" + query
+    return query
 
 
-def _execute_and_fetchall(query: str, parameters=None, many=False, conn=None) -> List:
+def _create_idempotent_create_merge_table_query(query):
+    """
+    The creation of the merge table cannot be easily idempotent because adding
+    an "IF NOT EXISTS" will leave the added tables. This means that adding afterwards tables
+    into the merge table will throw errors. We cannot add an "IF NOT EXISTS" clause in the
+    "ADD TABLE TO MERGE TABLE" query because it doesn't exist.
+    So the approach we are taking is dropping the merge table each time and recreating it to
+    make the whole merge table creation idempotent.
+    """
+    prefix = "CREATE MERGE TABLE"
+    if prefix in query:
+        table_name = _get_table_name_on_query(query, prefix)
+        return f"DROP TABLE {table_name};" + query
+    return query
+
+
+def _create_idempotent_query(query: str) -> str:
+    """
+    This is a query optimization method to protect from the following edge case:
+    1) A udf starts running allocating memory,
+    2) a table creation query starts running,
+    3) the udf allocates more memory than monetdb can provide,
+    4) the container memory limit kills monetdb,
+    5) the table creation query returns with BrokenPipeError("Server closed the connection"),
+    6) when the monet_db_facade tries to rerun the failed query it receives a "Table already exists error"
+        because the table was created even though the connection was severed.
+
+    The solution to this is to make all queries idempotent.
+    """
+    idempotent_query = query
+
+    if UDF_EXECUTION_QUERY_PREFIX in idempotent_query:
+        idempotent_split_queries = [
+            _create_idempotent_insert_into_query(query)
+            for query in idempotent_query.strip().split(";")
+            if query
+        ]
+        idempotent_query = ";".join(idempotent_split_queries) + ";"
+
+    if "CREATE MERGE TABLE" in idempotent_query:
+        idempotent_split_queries = [
+            _create_idempotent_create_merge_table_query(query)
+            for query in idempotent_query.strip().split(";")
+            if query
+        ]
+        idempotent_query = ";".join(idempotent_split_queries) + ";"
+
+    if "CREATE" in idempotent_query:
+        idempotent_query = idempotent_query.replace(
+            "CREATE TABLE", "CREATE TABLE IF NOT EXISTS"
+        )
+        idempotent_query = idempotent_query.replace(
+            "CREATE REMOTE TABLE", "CREATE REMOTE TABLE IF NOT EXISTS"
+        )
+        idempotent_query = idempotent_query.replace(
+            "CREATE VIEW", "CREATE OR REPLACE VIEW"
+        )
+        idempotent_query = idempotent_query.replace(
+            "CREATE FUNCTION", "CREATE OR REPLACE FUNCTION"
+        )
+
+    if "DROP" in idempotent_query:
+        idempotent_query = idempotent_query.replace(
+            "DROP FUNCTION", "DROP FUNCTION IF EXISTS"
+        )
+        idempotent_query = idempotent_query.replace(
+            "DROP TABLE", "DROP TABLE IF EXISTS"
+        )
+        idempotent_query = idempotent_query.replace("DROP VIEW", "DROP VIEW IF EXISTS")
+    return idempotent_query
+
+
+def _execute_queries_with_error_handling(func):
+    @wraps(func)
+    def error_handling(**kwargs):
+        """
+        On the query execution we need to handle the 'BrokenPipeError' and 'pymonetdb.exceptions.DatabaseError' exceptions.
+        In these cases we try to recover the connection with the database for x amount of time (x should not exceed the timeout).
+        """
+
+        db_execution_dto = kwargs["db_execution_dto"]
+        idempotent_query = _create_idempotent_query(db_execution_dto.query)
+        idempotent_db_execution_dto = _DBExecutionDTO(
+            query=idempotent_query,
+            parameters=db_execution_dto.parameters,
+            timeout=db_execution_dto.timeout,
+        )
+        kwargs["db_execution_dto"] = idempotent_db_execution_dto
+
+        logger = logging.get_logger()
+        logger.debug(
+            f"query: {idempotent_db_execution_dto.query=} \n, parameters: {idempotent_db_execution_dto.parameters}"
+        )
+
+        attempts = 0
+        # The NODE tasks have a timeout, so there is no point of trying a longer period of time,
+        # the task will have timed out in the CONTROLLER.
+        # pow(2, attempts + 1) ~= the total amount of time sleeping until this point
+        while idempotent_db_execution_dto.timeout > pow(2, attempts + 1):
+            try:
+                return func(**kwargs)
+            except ProgrammingError as exc:
+                logger.error(
+                    f"Error occurred: Exception type: '{type(exc)}' and exception message: '{exc}'"
+                )
+                raise exc
+            except (BrokenPipeError, pymonetdb.exceptions.DatabaseError) as exc:
+                if isinstance(exc, ProgrammingError) and "3F000!" in exc:
+                    logger.error(
+                        f"Error occurred: Exception type: '{type(exc)}' and exception message: '{exc}'"
+                    )
+                    raise exc
+                logger.warning(
+                    f"Trying to recover the connection with the database."
+                    f"Exception type: '{type(exc)}' and exception message: '{exc}'."
+                    f"Attempts={attempts}"
+                )
+                # To avoid the flooding of the request to the monetdb when a 'connection error' occur.
+                # We retry with a larger interval each time.
+                sleep(pow(2, attempts))
+                attempts += 1
+            except Exception as exc:
+                logger.error(
+                    f"Error occurred: Exception type: '{type(exc)}' and exception message: '{exc}'"
+                )
+                raise exc
+
+        connection_error_message = f"Failed to connect with the database. {attempts=}"
+        logger.error(connection_error_message)
+        raise ConnectionError(connection_error_message)
+
+    return error_handling
+
+
+@_execute_queries_with_error_handling
+def _execute_and_fetchall(db_execution_dto) -> List:
     """
     Used to execute only select queries that return a result.
-
-    'many' option to provide the functionality of executemany, all results will be fetched.
     'parameters' option to provide the functionality of bind-parameters.
     """
-    logger = logging.get_logger()
-    db_execution_dto = _DBExecutionDTO(query=query, parameters=parameters, many=many)
-    logger.info(
-        f"query: {db_execution_dto.query} \n, parameters: {str(db_execution_dto.parameters)}\n, many: {db_execution_dto.many}"
-    )
-
-    with _cursor(conn) as cur:
-        cur.executemany(
-            db_execution_dto.query, db_execution_dto.parameters
-        ) if db_execution_dto.many else cur.execute(
-            db_execution_dto.query, db_execution_dto.parameters
-        )
+    with _cursor() as cur:
+        cur.execute(db_execution_dto.query, db_execution_dto.parameters)
         result = cur.fetchall()
     return result
 
 
-def _execute(query: str, parameters=None, many=False, conn=None):
+@_execute_queries_with_error_handling
+def _execute(db_execution_dto: _DBExecutionDTO, lock):
     """
     Executes statements that don't have a result. For example "CREATE,DROP,UPDATE,INSERT".
 
@@ -177,102 +279,61 @@ def _execute(query: str, parameters=None, many=False, conn=None):
     By adding insert_query_lock we serialized the execution of the queries that contain 'INSERT INTO'.
     We need this insert_query_lock in order to ensure that we will have the zero-cost that the monetdb provides on the udfs.
 
-    'many' option to provide the functionality of executemany.
     'parameters' option to provide the functionality of bind-parameters.
     """
-    logger = logging.get_logger()
-
-    idempotent_query = _create_idempotent_query(query)
-    db_execution_dto = _DBExecutionDTO(
-        query=idempotent_query, parameters=parameters, many=many
-    )
-
-    logger.info(
-        f"Query: {idempotent_query} \n, "
-        f"parameters: {str(db_execution_dto.parameters)}\n, "
-        f"many: {db_execution_dto.many}"
-    )
-
-    query_execution_lock_timeout = node_config.celery.tasks_timeout
-    udf_execution_lock_timeout = node_config.celery.run_udf_task_timeout
-    lock_dto = (
-        _LockDTO(udf_execution_lock, udf_execution_lock_timeout)
-        if db_execution_dto.query.startswith("INSERT INTO")
-        else _LockDTO(query_execution_lock, query_execution_lock_timeout)
-    )
 
     try:
-        with _lock(lock_dto.lock, lock_dto.timeout):
-            _execute_and_commit(conn, db_execution_dto)
+        with _lock(lock, db_execution_dto.timeout):
+            with _cursor(commit=True) as cur:
+                cur.execute(db_execution_dto.query, db_execution_dto.parameters)
     except TimeoutError:
-        error_msg = _get_lock_timeout_error_msg(db_execution_dto, lock_dto.timeout)
+        error_msg = f"""
+        The execution of {db_execution_dto} failed because the
+        lock was not acquired during
+        {db_execution_dto.timeout}
+        """
         raise TimeoutError(error_msg)
 
 
-def _get_lock_timeout_error_msg(db_execution_dto, lock_timeout):
-    return f"""
-        query: {db_execution_dto.query=} with parameters:
-        {str(db_execution_dto.parameters)} and
-        {db_execution_dto.many=} was not executed because the
-        lock was not acquired during
-        {lock_timeout=}
-    """
-
-
-def _create_idempotent_query(query: str):
-    """
-    This is a query optimization method to protect from the following edge case:
-    1) A udf starts running allocating memory,
-    2) a table creation query starts running,
-    3) the udf allocates more memory than monetdb can provide,
-    4) the container memory limit kills monetdb,
-    5) the table creation query returns with BrokenPipeError("Server closed the connection"),
-    6) when the monet_db_facade tries to rerun the failed query it receives a "Table already exists error"
-        because the table was created even though the connection was severed.
-
-    The solution to this is to make all queries idempotent.
-    """
-    idempotent_query = query
-    create_merge_table_str = "CREATE MERGE TABLE"
-    if create_merge_table_str in idempotent_query:
-        """
-        The creation of the merge table cannot be easily idempotent because adding
-        an "IF NOT EXISTS" will leave the added tables. This means that adding afterwards tables
-        into the merge table will throw errors. We cannot add an "IF NOT EXISTS" clause in the
-        "ADD TABLE TO MERGE TABLE" query because it doesn't exist.
-        So the approach we are taking is dropping the merge table each time and recreating it to
-        make the whole merge table creation idempotent.
-        """
-
-        # We need to extract the table name from the query
-        create_merge_table_pos = idempotent_query.find(create_merge_table_str)
-        create_merge_table_name, *_ = idempotent_query[
-            create_merge_table_pos + len(create_merge_table_str) :
-        ].split()
-
-        idempotent_query = idempotent_query.replace(
-            "CREATE MERGE TABLE",
-            f"DROP TABLE {create_merge_table_name}; CREATE MERGE TABLE",
-        )
-
-    if "CREATE" in idempotent_query:
-        idempotent_query = idempotent_query.replace(
-            "CREATE TABLE", "CREATE TABLE IF NOT EXISTS"
-        )
-        idempotent_query = idempotent_query.replace(
-            "CREATE REMOTE TABLE", "CREATE REMOTE TABLE IF NOT EXISTS"
-        )
-        idempotent_query = idempotent_query.replace(
-            "CREATE VIEW", "CREATE OR REPLACE VIEW"
-        )
-
-    if "DROP" in idempotent_query:
-        idempotent_query = idempotent_query.replace(
-            "DROP FUNCTION", "DROP FUNCTION IF EXISTS"
-        )
-        idempotent_query = idempotent_query.replace(
-            "DROP TABLE", "DROP TABLE IF EXISTS"
-        )
-        idempotent_query = idempotent_query.replace("DROP VIEW", "DROP VIEW IF EXISTS")
-
-    return idempotent_query
+# Connection Pool disabled due to bugs in maintaining connections
+# class _MonetDBConnectionPool(metaclass=Singleton):
+#     """
+#     MonetDBConnectionPool is a Singleton class.
+#
+#     We use pseudo-multithreading(eventlet greenlets),
+#     we provide a connection pool to support concurrent query execution.
+#     """
+#
+#     def __init__(self):
+#         self._connection_pool = []
+#
+#     def create_connection(self):
+#         return pymonetdb.connect(
+#             hostname=node_config.monetdb.ip,
+#             port=node_config.monetdb.port,
+#             username=node_config.monetdb.username,
+#             password=node_config.monetdb.password,
+#             database=node_config.monetdb.database,
+#         )
+#
+#     def clear(self):
+#         self._connection_pool.clear()
+#
+#     def get_connection(self):
+#         """
+#         We use pseudo-multithreading (eventlet greenlets) by committing before a query we refresh the state
+#         of the connection so that it sees changes from other connections.
+#         https://stackoverflow.com/questions/9305669/mysql-python-connection-does-not-see-changes-to-database-made
+#         """
+#         if not self._connection_pool:
+#             connection = self.create_connection()
+#         else:
+#             connection = self._connection_pool.pop()
+#         connection.commit()
+#
+#         return connection
+#
+#     def release_connection(self, connection):
+#         connection.commit()
+#         self._connection_pool.append(connection)
+#

--- a/mipengine/node/tasks/tables.py
+++ b/mipengine/node/tasks/tables.py
@@ -69,6 +69,7 @@ def create_table(
     ).json()
 
 
+# TODO: https://team-1617704806227.atlassian.net/browse/MIP-762
 @shared_task
 @initialise_logger
 def insert_data_to_table(

--- a/monetdb/Dockerfile
+++ b/monetdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM madgik/mipenginedb_base
+FROM madgik/mipenginedb_base:0.1
 
 #######################################################
 # Download monetdb source files
@@ -37,8 +37,10 @@ RUN dpkg -i libstreams0v5_0.7.8-2.2_amd64.deb libstreams-dev_0.7.8-2.2_amd64.deb
 #######################################################
 COPY monetdb/bootstrap.sh /home/bootstrap.sh
 COPY monetdb/configure_users.sh /home/configure_users.sh
+COPY monetdb/configure_monit.sh /home/configure_monit.sh
 RUN chmod 775 /home/bootstrap.sh
 RUN chmod 775 /home/configure_users.sh
+RUN chmod 775 /home/configure_monit.sh
 
 #######################################################
 # Setup logrotate file
@@ -81,6 +83,13 @@ ENV GUEST_PASSWORD='guest'
 ENV MONETDB_NCLIENTS=64
 ENV MONETDB_STORAGE=/home/monetdb
 VOLUME $MONETDB_STORAGE
+
+#######################################################
+# Configure monit
+#######################################################
+ENV MONIT_CONFIG_FOLDER=/home/monit
+RUN mkdir $MONIT_CONFIG_FOLDER
+
 
 WORKDIR /home
 CMD ["/bin/bash","/home/bootstrap.sh"]

--- a/monetdb/DockerfileBaseImage
+++ b/monetdb/DockerfileBaseImage
@@ -23,3 +23,4 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 RUN apt update && apt install -y libssl-dev libpcre3 libpcre3-dev pkg-config uuid-dev libxml2 libxml2-dev unixodbc-dev build-essential logrotate
 RUN apt update && apt install -y python3-pip
+RUN apt update && apt install -y monit

--- a/monetdb/bootstrap.sh
+++ b/monetdb/bootstrap.sh
@@ -43,6 +43,7 @@ else
 fi
 
 ./configure_users.sh
+./configure_monit.sh
 
 echo 'MonetDB merovingian logs:'
-tail -fn +1 $MONETDB_STORAGE/merovingian.log
+tail -fn +1 $MONETDB_STORAGE/merovingian.log -fn +1 $MONIT_CONFIG_FOLDER/monit.log

--- a/monetdb/configure_monit.sh
+++ b/monetdb/configure_monit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+cat << EOF > /etc/monit/monitrc
+# Monit configurations
+  set log $MONIT_CONFIG_FOLDER/monit.log
+  set idfile $MONIT_CONFIG_FOLDER/id
+  set statefile $MONIT_CONFIG_FOLDER/state
+
+# Monit cycle time
+  set daemon 1 #The amount of seconds for each cycle
+
+# Monit monetdb monitor
+  check process monetdb matching mserver
+    start program = "/bin/bash -c '/usr/local/bin/monetdb/bin/monetdb release db && /usr/local/bin/monetdb/bin/monetdb start db'"
+    stop program  = "/bin/bash -c '/usr/local/bin/monetdb/bin/monetdb lock db && /usr/local/bin/monetdb/bin/monetdb stop db'"
+    if totalmem > $SOFT_RESTART_MEMORY_LIMIT MB for 10 cycles then restart
+    if totalmem > $HARD_RESTART_MEMORY_LIMIT MB for 1 cycles then restart
+EOF
+
+monit
+monit reload

--- a/monetdb/logrotate.conf
+++ b/monetdb/logrotate.conf
@@ -13,3 +13,11 @@
   compress
   notifempty
 }
+
+/home/monit/monit.log {
+  size 10M
+  copytruncate
+  rotate 4
+  compress
+  notifempty
+}

--- a/tasks.py
+++ b/tasks.py
@@ -331,7 +331,7 @@ def create_monetdb(
             f"Starting container {container_name} on ports {container_ports}...",
             Level.HEADER,
         )
-        cmd = f"""docker run -d -P -p {container_ports} -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
+        cmd = f"""docker run -d -P -p {container_ports} -e SOFT_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.7} -e HARD_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.85}  -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
         run(c, cmd)
 
 
@@ -384,7 +384,7 @@ def load_data(c, use_sockets=False, port=None):
         port = local_node_ports[0]
         cmd = f"poetry run mipdb load-folder {TEST_DATA_FOLDER} --copy_from_file {not use_sockets} {get_monetdb_configs_in_mipdb_format(port)}"
         message(
-            f"Loading the folder '{TEST_DATA_FOLDER}' in MonetDB at port {port}...",
+            f"Loading the folder '{TEST_DATA_FOLDER}' in MonetDB at port {local_node_ports[0]}...",
             Level.HEADER,
         )
         run(c, cmd)

--- a/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
+++ b/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
@@ -12,7 +12,9 @@ max_concurrent_experiments: 32
 db:
   storage_location: /opt/mipengine/db
   csvs_location: /opt/mipengine/csvs
-  max_memory: 1024Mi    # k8s memory limit
+  max_memory: 1024    # k8s memory limit in megabytes
+  percentage_soft_memory_limit: 65
+  percentage_hard_memory_limit: 85
 
 controller:
   node_landscape_aggregator_update_interval: 20

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -20,7 +20,6 @@ from mipengine.controller.algorithm_execution_engine_tasks_handler import (
 )
 from mipengine.controller.celery_app import CeleryAppFactory
 from mipengine.controller.controller_logger import init_logger
-from mipengine.node.monetdb_interface.monet_db_facade import _MonetDBConnectionPool
 from mipengine.udfgen import udfio
 
 ALGORITHM_FOLDERS_ENV_VARIABLE_VALUE = "./mipengine/algorithms,./tests/algorithms"
@@ -574,11 +573,6 @@ def _clean_db(cursor):
                 cursor.execute(f"DROP VIEW {table_name}")
             else:
                 cursor.execute(f"DROP TABLE {table_name}")
-
-
-@pytest.fixture(scope="function")
-def reset_monet_db_facade_connection_pool():
-    _MonetDBConnectionPool()._connection_pool = []
 
 
 @pytest.fixture(scope="function")

--- a/tests/standalone_tests/test_cleanup_after_algorithm_execution.py
+++ b/tests/standalone_tests/test_cleanup_after_algorithm_execution.py
@@ -217,7 +217,9 @@ def node_landscape_aggregator(
     node_landscape_aggregator._update()
     node_landscape_aggregator.start()
 
-    return node_landscape_aggregator
+    # TODO https://team-1617704806227.atlassian.net/jira/software/projects/MIP/issues/MIP-771
+    yield node_landscape_aggregator
+    del node_landscape_aggregator
 
 
 @pytest.fixture(scope="function")
@@ -315,7 +317,9 @@ def cleaner(controller_config, node_landscape_aggregator):
         contextids_cleanup_folder=controller_config.cleanup.contextids_cleanup_folder,
         node_landscape_aggregator=node_landscape_aggregator,
     )
-    return Cleaner(cleaner_init_params)
+    cleaner = Cleaner(cleaner_init_params)
+    yield cleaner
+    del cleaner
 
 
 @pytest.fixture

--- a/tests/standalone_tests/test_monet_db_facade.py
+++ b/tests/standalone_tests/test_monet_db_facade.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch
 
-import pymonetdb
 import pytest
 
 from mipengine import AttrDict
+from mipengine.node.monetdb_interface.monet_db_facade import _DBExecutionDTO
+from mipengine.node.monetdb_interface.monet_db_facade import _execute_and_fetchall
 from mipengine.node.monetdb_interface.monet_db_facade import db_execute_and_fetchall
 from mipengine.node.node_logger import init_logger
 from tests.standalone_tests.conftest import COMMON_IP
@@ -64,7 +65,6 @@ def patch_node_config():
 @pytest.mark.very_slow
 def test_execute_and_fetchall_success(
     monetdb_localnodetmp,
-    reset_monet_db_facade_connection_pool,
 ):
     result = db_execute_and_fetchall(query="SELECT 1;")
     assert result[0][0] == 1
@@ -75,51 +75,26 @@ def test_execute_and_fetchall_success(
 def test_broken_pipe_error_properly_handled(
     capfd,
     monetdb_localnodetmp,
-    reset_monet_db_facade_connection_pool,
 ):
     result = db_execute_and_fetchall(query="SELECT 1;")
     assert result[0][0] == 1
     restart_monetdb_container(MONETDB_LOCALNODETMP_NAME)
     result = db_execute_and_fetchall(query="SELECT 1;")
-    _, err = capfd.readouterr()
-    assert (
-        "Trying to recover the connection with the database. Exception type: '<class 'BrokenPipeError'>'"
-        in err
-    )
     assert result[0][0] == 1
-
-
-@pytest.mark.slow
-@pytest.mark.very_slow
-def test_connection_refused_properly_handled(
-    capfd,
-    monetdb_localnodetmp,
-    reset_monet_db_facade_connection_pool,
-):
-    remove_monetdb_container(MONETDB_LOCALNODETMP_NAME)
-    with pytest.raises(ConnectionError):
-        db_execute_and_fetchall(query="SELECT 1;")
-    out, err = capfd.readouterr()
-    assert (
-        "Trying to recover the connection with the database. Exception type: '<class 'OSError'>'"
-        in err
-    )
 
 
 @pytest.mark.slow
 @pytest.mark.very_slow
 def test_generic_exception_handled(
     monetdb_localnodetmp,
-    reset_monet_db_facade_connection_pool,
 ):
-    with pytest.raises(pymonetdb.exceptions.OperationalError):
-        db_execute_and_fetchall(query="SELECT * FROM non_existing_table;")
+    remove_monetdb_container(MONETDB_LOCALNODETMP_NAME)
+    db_execution_dto = _DBExecutionDTO(query="select 1;", timeout=3)
+    with pytest.raises(OSError):
+        _execute_and_fetchall(db_execution_dto=db_execution_dto)
 
 
-def test_connection_refused_with_stopped_monetdb_container(
-    reset_monet_db_facade_connection_pool,
-):
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade.CONN_RECOVERY_MAX_ATTEMPTS", 1
-    ), pytest.raises(ConnectionError):
-        db_execute_and_fetchall(query="SELECT 1;")
+def test_connection_refused_with_stopped_monetdb_container():
+    db_execution_dto = _DBExecutionDTO(query="select 1;", timeout=1)
+    with pytest.raises(ConnectionError):
+        _execute_and_fetchall(db_execution_dto=db_execution_dto)

--- a/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
+++ b/tests/standalone_tests/test_monetdb_interface_if_not_exists.py
@@ -4,10 +4,13 @@ import pytest
 
 from mipengine import AttrDict
 from mipengine import DType
+from mipengine.node.monetdb_interface.common_actions import get_table_data
 from mipengine.node.monetdb_interface.merge_tables import create_merge_table
-from mipengine.node.monetdb_interface.monet_db_facade import _execute
+from mipengine.node.monetdb_interface.monet_db_facade import _create_idempotent_query
+from mipengine.node.monetdb_interface.monet_db_facade import _db_execute_udf
 from mipengine.node.monetdb_interface.remote_tables import create_remote_table
 from mipengine.node.monetdb_interface.tables import create_table
+from mipengine.node.monetdb_interface.tables import insert_data_to_table
 from mipengine.node.monetdb_interface.views import create_view
 from mipengine.node.node_logger import init_logger
 from mipengine.node_tasks_DTOs import ColumnInfo
@@ -140,6 +143,33 @@ def test_create_table_if_not_exists(
 
 
 @pytest.mark.slow
+def test_insert_into_table_if_empty(
+    use_localnode1_database,
+):
+    table_name = "test_insert_into_table_if_empty"
+    table_schema = TableSchema(
+        columns=[ColumnInfo(name="sample_column", dtype=DType.INT)]
+    )
+    create_table(
+        table_name=table_name,
+        table_schema=table_schema,
+    )
+
+    insert_data_to_table(
+        table_name=table_name,
+        table_values=[[1], [2]],
+    )
+    insert_data_to_table(
+        table_name=table_name,
+        table_values=[[3], [4]],
+    )
+    [column] = get_table_data(table_name)
+    data = column.data
+    if data != [3, 4]:
+        pytest.fail("Each insert into should clear and re-add the values")
+
+
+@pytest.mark.slow
 def test_create_remote_table_if_not_exists(
     use_localnode1_database,
 ):
@@ -197,70 +227,86 @@ def test_create_merge_table_if_not_exists(
         )
 
 
-def test_create_table_if_not_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("CREATE TABLE")
-        assert (
-            execute_and_commit_mock.call_args.args[1].query
-            == "CREATE TABLE IF NOT EXISTS"
-        )
+def test_udf_execution_query_should_contain_only_one_query():
+    with pytest.raises(ValueError):
+        _db_execute_udf(query="INSERT INTO table1 func1();INSERT INTO table2 func2();")
 
 
-def test_create_remote_table_if_not_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("CREATE REMOTE TABLE")
-        assert (
-            execute_and_commit_mock.call_args.args[1].query
-            == "CREATE REMOTE TABLE IF NOT EXISTS"
-        )
+def get_idempotent_query_cases():
+    return [
+        pytest.param(
+            "INSERT INTO table1 values ();INSERT INTO table2 values ();",
+            "DELETE FROM table1;INSERT INTO table1 values ();DELETE FROM table2;INSERT INTO table2 values ();",
+            id="insert into if values are not present",
+        ),
+        pytest.param(
+            "CREATE TABLE table1 ();CREATE TABLE table2 ();",
+            "CREATE TABLE IF NOT EXISTS table1 ();CREATE TABLE IF NOT EXISTS table2 ();",
+            id="create table if not exists query",
+        ),
+        pytest.param(
+            "CREATE REMOTE TABLE table1 ();CREATE REMOTE TABLE table2 ();",
+            "CREATE REMOTE TABLE IF NOT EXISTS table1 ();CREATE REMOTE TABLE IF NOT EXISTS table2 ();",
+            id="create remote table if not exists query",
+        ),
+        pytest.param(
+            "CREATE MERGE TABLE table1 ();CREATE MERGE TABLE table2 ();",
+            "DROP TABLE IF EXISTS table1;CREATE MERGE TABLE table1 ();DROP TABLE IF EXISTS table2;CREATE MERGE TABLE table2 ();",
+            id="create merge table if not exists query",
+        ),
+        pytest.param(
+            "CREATE VIEW view1 as ();CREATE VIEW view2 as ();",
+            "CREATE OR REPLACE VIEW view1 as ();CREATE OR REPLACE VIEW view2 as ();",
+            id="mutliple create view if not exists query",
+        ),
+        pytest.param(
+            "DROP VIEW view1;DROP VIEW view2;",
+            "DROP VIEW IF EXISTS view1;DROP VIEW IF EXISTS view2;",
+            id="drop view if exists query",
+        ),
+        pytest.param(
+            "DROP TABLE table1;DROP TABLE table2;",
+            "DROP TABLE IF EXISTS table1;DROP TABLE IF EXISTS table2;",
+            id="mutliple drop table if exists query",
+        ),
+        pytest.param(
+            "DROP FUNCTION func1;DROP FUNCTION func2;",
+            "DROP FUNCTION IF EXISTS func1;DROP FUNCTION IF EXISTS func2;",
+            id="drop function if exists",
+        ),
+        pytest.param(
+            "CREATE TABLE sample_table (col1);"
+            "INSERT INTO sample_table VALUES(1);"
+            "CREATE REMOTE TABLE sample_remote_table;"
+            "CREATE MERGE TABLE sample_merge_table (col1);"
+            "CREATE VIEW sample_view as ();"
+            "CREATE FUNCTION sample_func stuff;"
+            "DROP VIEW sample_view;"
+            "DROP TABLE sample_table;"
+            "DROP TABLE sample_remote_table;"
+            "DROP TABLE sample_merge_table;"
+            "DROP FUNCTION sample_func;",
+            "CREATE TABLE IF NOT EXISTS sample_table (col1);"
+            "DELETE FROM sample_table;"
+            "INSERT INTO sample_table VALUES(1);"
+            "CREATE REMOTE TABLE IF NOT EXISTS sample_remote_table;"
+            "DROP TABLE IF EXISTS sample_merge_table;"
+            "CREATE MERGE TABLE sample_merge_table (col1);"
+            "CREATE OR REPLACE VIEW sample_view as ();"
+            "CREATE OR REPLACE FUNCTION sample_func stuff;"
+            "DROP VIEW IF EXISTS sample_view;"
+            "DROP TABLE IF EXISTS sample_table;"
+            "DROP TABLE IF EXISTS sample_remote_table;"
+            "DROP TABLE IF EXISTS sample_merge_table;"
+            "DROP FUNCTION IF EXISTS sample_func;",
+            id="multiple different queries",
+        ),
+    ]
 
 
-def test_create_merge_table_if_not_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("CREATE MERGE TABLE sample_table")
-        assert (
-            execute_and_commit_mock.call_args.args[1].query
-            == "DROP TABLE IF EXISTS sample_table; CREATE MERGE TABLE sample_table"
-        )
-
-
-def test_create_view_if_not_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("CREATE VIEW")
-        assert (
-            execute_and_commit_mock.call_args.args[1].query == "CREATE OR REPLACE VIEW"
-        )
-
-
-def test_drop_view_if_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("DROP VIEW")
-        assert execute_and_commit_mock.call_args.args[1].query == "DROP VIEW IF EXISTS"
-
-
-def test_drop_table_if_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("DROP TABLE")
-        assert execute_and_commit_mock.call_args.args[1].query == "DROP TABLE IF EXISTS"
-
-
-def test_drop_function_if_exists_query():
-    with patch(
-        "mipengine.node.monetdb_interface.monet_db_facade._execute_and_commit"
-    ) as execute_and_commit_mock:
-        _execute("DROP FUNCTION")
-        assert (
-            execute_and_commit_mock.call_args.args[1].query == "DROP FUNCTION IF EXISTS"
-        )
+@pytest.mark.parametrize(
+    "original_query,excpected_idempotent_query",
+    get_idempotent_query_cases(),
+)
+def test_create_idempotent_query(original_query: str, excpected_idempotent_query: str):
+    assert _create_idempotent_query(original_query) == excpected_idempotent_query


### PR DESCRIPTION
Changelog:
https://team-1617704806227.atlassian.net/browse/MIP-732. 
I implemented a first attempt to fix most of the problem with the monetdb.
https://team-1617704806227.atlassian.net/browse/MIP-731.


Refactored monet_db_facade.py.

1. Removed the many functionality from pymonetdb, because the is not compatible with the idempotent queries.
2. Added the case of 'insert into' to the idempotent queries.
3. Removed the _MonetDBConnectionPool.
4. Now for each query execution we create and close a connection.
5. Now monetdb facede will retry(x amount of times) to execute a query in case the error "table not found" is thrown. This fixes the MIP-731.

Added Monitoring tool 'Monit' to the monetdb configuration.

1. Now monit will monitor the monetdb resource allocation.
2. Added two actions on the monit  'hard memory limit' and 'soft memory limit'
3. Soft/Hard memory limit will trigger once the memory of the system is above 70%/85%.
4. Once soft limit is trigger, the monit will check if in the following 10 the memory usage drops below 70%, in case it does not the monit will lock, restart and then release again the database.
6. Once hard limit is trigger monit will instantly lock, restart and then release again the database.
