### PR TITLE
Dev/mip 759/add new longitudinal transformation parameter properties

### DIFF
--- a/mipengine/controller/api/algorithm_specifications_dtos.py
+++ b/mipengine/controller/api/algorithm_specifications_dtos.py
@@ -34,6 +34,7 @@ class ParameterType(str, Enum):
     INT = "int"
     TEXT = "text"
     BOOLEAN = "boolean"
+    DICT = "dict"
 
 
 @unique
@@ -75,6 +76,8 @@ class ParameterSpecificationDTO(ImmutableBaseModel):
     multiple: bool
     default: Any
     enums: Optional[ParameterEnumSpecificationDTO]
+    dict_keys_enums: Optional[ParameterEnumSpecificationDTO]
+    dict_values_enums: Optional[ParameterEnumSpecificationDTO]
     min: Optional[float]
     max: Optional[float]
 

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -10,7 +10,10 @@ from mipengine.controller.algorithm_specifications import ParameterEnumSpecifica
 from mipengine.controller.algorithm_specifications import ParameterSpecification
 from mipengine.controller.api.algorithm_request_dto import AlgorithmInputDataDTO
 from mipengine.controller.api.algorithm_request_dto import AlgorithmRequestDTO
+from mipengine.controller.api.algorithm_specifications_dtos import InputDataStatType
+from mipengine.controller.api.algorithm_specifications_dtos import InputDataType
 from mipengine.controller.api.algorithm_specifications_dtos import ParameterEnumType
+from mipengine.controller.api.algorithm_specifications_dtos import ParameterType
 from mipengine.controller.api.validator import BadRequest
 from mipengine.controller.api.validator import validate_algorithm_request
 from mipengine.controller.node_landscape_aggregator import DataModelRegistry
@@ -117,8 +120,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="features",
                     desc="Features",
-                    types=["real"],
-                    stattypes=["numerical"],
+                    types=[InputDataType.REAL],
+                    stattypes=[InputDataStatType.NUMERICAL],
                     notblank=True,
                     multiple=False,
                 ),
@@ -133,16 +136,16 @@ def mock_algorithms_specs():
                 x=InputDataSpecification(
                     label="features",
                     desc="Features",
-                    types=["real"],
-                    stattypes=["numerical"],
+                    types=[InputDataType.REAL],
+                    stattypes=[InputDataStatType.NUMERICAL],
                     notblank=True,
                     multiple=False,
                 ),
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
                     notblank=True,
                     multiple=False,
                 ),
@@ -157,8 +160,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal", "numerical"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL, InputDataStatType.NUMERICAL],
                     notblank=True,
                     multiple=True,
                 ),
@@ -173,8 +176,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
                     notblank=True,
                     multiple=True,
                 ),
@@ -189,8 +192,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["numerical"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NUMERICAL],
                     notblank=True,
                     multiple=True,
                 ),
@@ -205,8 +208,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
                     notblank=True,
                     multiple=False,
                     enumslen=2,
@@ -222,16 +225,16 @@ def mock_algorithms_specs():
                 x=InputDataSpecification(
                     label="features",
                     desc="Features",
-                    types=["real"],
-                    stattypes=["numerical"],
+                    types=[InputDataType.REAL],
+                    stattypes=[InputDataStatType.NUMERICAL],
                     notblank=False,
                     multiple=False,
                 ),
                 y=InputDataSpecification(
                     label="target",
                     desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal"],
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
                     notblank=True,
                     multiple=False,
                 ),
@@ -246,8 +249,8 @@ def mock_algorithms_specs():
                 y=InputDataSpecification(
                     label="features",
                     desc="Features",
-                    types=["real"],
-                    stattypes=["numerical"],
+                    types=[InputDataType.REAL],
+                    stattypes=[InputDataStatType.NUMERICAL],
                     notblank=True,
                     multiple=False,
                 ),
@@ -256,23 +259,31 @@ def mock_algorithms_specs():
                 "required_param": ParameterSpecification(
                     label="required_param",
                     desc="required_param",
-                    types=["real"],
+                    types=[ParameterType.REAL],
                     notblank=True,
                     multiple=False,
                 ),
             },
         ),
         "algorithm_with_many_params": AlgorithmSpecification(
-            name="algorithm_with_x_and_y",
-            desc="algorithm_with_x_and_y",
-            label="algorithm_with_x_and_y",
+            name="algorithm_with_many_params",
+            desc="algorithm_with_many_params",
+            label="algorithm_with_many_params",
             enabled=True,
             inputdata=InputDataSpecifications(
+                x=InputDataSpecification(
+                    label="x",
+                    desc="x",
+                    types=[InputDataType.INT, InputDataType.REAL],
+                    stattypes=[InputDataStatType.NUMERICAL],
+                    notblank=False,
+                    multiple=True,
+                ),
                 y=InputDataSpecification(
-                    label="target",
-                    desc="Target variable",
-                    types=["text"],
-                    stattypes=["nominal"],
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
                     notblank=True,
                     multiple=False,
                 ),
@@ -281,7 +292,7 @@ def mock_algorithms_specs():
                 "int_parameter_with_min_max": ParameterSpecification(
                     label="parameter_with_min_max",
                     desc="parameter_with_min_max",
-                    types=["int"],
+                    types=[ParameterType.INT],
                     notblank=False,
                     multiple=False,
                     min=2,
@@ -290,21 +301,21 @@ def mock_algorithms_specs():
                 "text_parameter": ParameterSpecification(
                     label="text_parameter",
                     desc="text_parameter",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                 ),
                 "parameter_multiple_true": ParameterSpecification(
                     label="parameter_multiple_true",
                     desc="parameter_multiple_true",
-                    types=["int"],
+                    types=[ParameterType.INT],
                     notblank=False,
                     multiple=True,
                 ),
                 "param_with_enum_type_list": ParameterSpecification(
                     label="param_with_enum_type_list",
                     desc="param_with_enum_type_list",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
@@ -315,7 +326,7 @@ def mock_algorithms_specs():
                 "param_with_enum_type_list_multiple_true": ParameterSpecification(
                     label="param_with_enum_type_list_multiple_true",
                     desc="param_with_enum_type_list_multiple_true",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=True,
                     enums=ParameterEnumSpecification(
@@ -326,7 +337,7 @@ def mock_algorithms_specs():
                 "param_with_enum_type_input_var_CDE_enums": ParameterSpecification(
                     label="param_with_enum_type_input_var_CDE_enums",
                     desc="param_with_enum_type_input_var_CDE_enums",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
@@ -337,7 +348,7 @@ def mock_algorithms_specs():
                 "param_with_enum_type_fixed_var_CDE_enums": ParameterSpecification(
                     label="param_with_enum_type_fixed_var_CDE_enums",
                     desc="param_with_enum_type_fixed_var_CDE_enums",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
@@ -348,7 +359,7 @@ def mock_algorithms_specs():
                 "param_with_enum_type_fixed_var_CDE_enums_wrong_CDE": ParameterSpecification(
                     label="param_with_enum_type_fixed_var_CDE_enums_wrong_CDE",
                     desc="param_with_enum_type_fixed_var_CDE_enums_wrong_CDE",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
@@ -359,12 +370,34 @@ def mock_algorithms_specs():
                 "param_with_enum_type_input_var_names": ParameterSpecification(
                     label="param_with_enum_type_input_var_names",
                     desc="param_with_enum_type_input_var_names",
-                    types=["text"],
+                    types=[ParameterType.TEXT],
                     notblank=False,
                     multiple=False,
                     enums=ParameterEnumSpecification(
                         type=ParameterEnumType.INPUT_VAR_NAMES,
                         source=["x", "y"],
+                    ),
+                ),
+                "param_with_type_dict": ParameterSpecification(
+                    label="param_with_type_dict",
+                    desc="param_with_type_dict",
+                    types=[ParameterType.DICT],
+                    notblank=False,
+                    multiple=False,
+                ),
+                "param_with_dict_enums": ParameterSpecification(
+                    label="param_with_dict_enums",
+                    desc="param_with_dict_enums",
+                    types=[ParameterType.DICT],
+                    notblank=False,
+                    multiple=False,
+                    dict_keys_enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.INPUT_VAR_NAMES,
+                        source=["x", "y"],
+                    ),
+                    dict_values_enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.LIST,
+                        source=["diff", "first", "second"],
                     ),
                 ),
             },
@@ -542,6 +575,37 @@ def get_parametrization_list_success_cases():
                 parameters={"param_with_enum_type_input_var_names": "text_cde_categ"},
             ),
             id="parameter enums type input_var_names",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={"param_with_type_dict": {"sample_key": "sample_value"}},
+            ),
+            id="Parameter with type dict.",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    x=["int_cde", "real_cde"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={
+                    "param_with_dict_enums": {
+                        "text_cde_categ": "first",
+                        "int_cde": "diff",
+                        "real_cde": "diff",
+                    }
+                },
+            ),
+            id="Parameter with dict enums.",
         ),
     ]
     return parametrization_list
@@ -770,6 +834,19 @@ def get_parametrization_list_exception_cases():
                     datasets=["sample_dataset1"],
                     y=["text_cde_categ"],
                 ),
+                parameters={"param_with_type_dict": "text_value"},
+            ),
+            (BadUserInput, "Parameter .* values should be of types.*"),
+            id="Parameter of type dict given wrong value.",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
                 parameters={"int_parameter_with_min_max": [1, 2, 3]},
             ),
             (BadUserInput, "Parameter .* values should be of types.*"),
@@ -830,7 +907,7 @@ def get_parametrization_list_exception_cases():
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .* given in inputdata .* variable, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type input_var_CDE_enums given non existing enum.",
+            id="Parameter with enumerations of type 'input_var_CDE_enums' given non existing enum.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -848,7 +925,7 @@ def get_parametrization_list_exception_cases():
                 ValueError,
                 "Parameter's .* enums source .* does not exist in the data model provided.",
             ),
-            id="Parameter with enumerations of type fixed_var_CDE_enums has, in the algorithm specification, a CDE that doesn't exist.",
+            id="Parameter with enumerations of type 'fixed_var_CDE_enums' has, in the algorithm specification, a CDE that doesn't exist.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -866,7 +943,7 @@ def get_parametrization_list_exception_cases():
                 BadUserInput,
                 "Parameter's .* enums, that are taken from the CDE .*, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type fixed_var_CDE_enums given non existing enum.",
+            id="Parameter with enumerations of type 'fixed_var_CDE_enums' given non existing enum.",
         ),
         pytest.param(
             "algorithm_with_many_params",
@@ -884,7 +961,47 @@ def get_parametrization_list_exception_cases():
                 BadUserInput,
                 "Parameter's .* enums, that are taken from inputdata .* var names, should be one of the following: .*",
             ),
-            id="Parameter with enumerations of type input_var_names given non existing enum.",
+            id="Parameter with enumerations of type 'input_var_names' given non existing enum.",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={
+                    "param_with_dict_enums": {
+                        "not_selected_CDE": "first",
+                    }
+                },
+            ),
+            (
+                BadUserInput,
+                "Parameter's .* enums, that are taken from inputdata .* var names, should be one of the following: .*",
+            ),
+            id="Parameter with 'dict_keys_enums' given wrong key enum.",
+        ),
+        pytest.param(
+            "algorithm_with_many_params",
+            AlgorithmRequestDTO(
+                inputdata=AlgorithmInputDataDTO(
+                    data_model="data_model_with_all_cde_types:0.1",
+                    datasets=["sample_dataset1"],
+                    y=["text_cde_categ"],
+                ),
+                parameters={
+                    "param_with_dict_enums": {
+                        "text_cde_categ": "non_existing_enum",
+                    }
+                },
+            ),
+            (
+                BadUserInput,
+                "Parameter .* values should be one of the following: .*",
+            ),
+            id="Parameter with 'dict_keys_enums' given wrong value enum.",
         ),
     ]
     return parametrization_list

--- a/tests/standalone_tests/test_validate_algorithm_specifications.py
+++ b/tests/standalone_tests/test_validate_algorithm_specifications.py
@@ -158,3 +158,148 @@ def test_validate_parameter_spec_input_var_names_type_must_be_text():
                 ),
             },
         )
+
+
+def test_validate_parameter_dict_type_given_with_other_type():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' cannot use 'dict' type combined"
+        " with other types. Types provided: .* "
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "dict_and_text_types_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=[ParameterType.DICT, ParameterType.TEXT],
+                    notblank=False,
+                    multiple=False,
+                ),
+            },
+        )
+
+
+def test_validate_parameter_property_dict_keys_enums_can_only_be_given_with_type_dict():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has the property 'dict_keys_enums' "
+        "but the allowed 'types' is not 'dict'."
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "dict_keys_enums_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=[ParameterType.TEXT],
+                    notblank=False,
+                    multiple=False,
+                    dict_keys_enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.LIST, source=["sample_enum"]
+                    ),
+                ),
+            },
+        )
+
+
+def test_validate_parameter_property_dict_values_enums_can_only_be_given_with_type_dict():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has the property 'dict_values_enums' "
+        "but the allowed 'types' is not 'dict'."
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "dict_values_enums_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=[ParameterType.TEXT],
+                    notblank=False,
+                    multiple=False,
+                    dict_values_enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.LIST, source=["sample_enum"]
+                    ),
+                ),
+            },
+        )
+
+
+def test_validate_parameter_property_enums_given_with_type_dict():
+    exception_type = ValidationError
+    exception_message = (
+        ".*In algorithm 'sample_algo', parameter 'sample_label' has the property 'enums' "
+        "but since the 'types' is 'dict', you should use 'dict_keys_enums' and 'dict_values_enums'."
+    )
+    with pytest.raises(exception_type, match=exception_message):
+        AlgorithmSpecification(
+            name="sample_algo",
+            desc="sample",
+            label="sample_algo",
+            enabled=True,
+            inputdata=InputDataSpecifications(
+                y=InputDataSpecification(
+                    label="y",
+                    desc="y",
+                    types=[InputDataType.TEXT],
+                    stattypes=[InputDataStatType.NOMINAL],
+                    notblank=True,
+                    multiple=False,
+                )
+            ),
+            parameters={
+                "dict_type_param": ParameterSpecification(
+                    label="sample_label",
+                    desc="sample",
+                    types=[ParameterType.DICT],
+                    notblank=False,
+                    multiple=False,
+                    enums=ParameterEnumSpecification(
+                        type=ParameterEnumType.LIST, source=["sample_enum"]
+                    ),
+                ),
+            },
+        )


### PR DESCRIPTION
Changelog:
  - Add support for longitudinal transformation parameter. [Jira](https://team-1617704806227.atlassian.net/browse/MIP-759)
  - Added new `dict` type in the algorithm specifications parameter types.
  - Added new `dict_keys_enums` and `dict_values_enums` to be used as enums for dict type parameters.