### PR TITLE
algorithms: bring back json spec files

### DIFF
--- a/mipengine/__init__.py
+++ b/mipengine/__init__.py
@@ -1,16 +1,14 @@
 import glob
 import importlib
 import os
-from importlib import util
 from os.path import basename
 from os.path import isfile
 from types import ModuleType
 from typing import Dict
 
 from mipengine.algorithms.algorithm import Algorithm
-
-from .attrdict import AttrDict
-from .datatypes import DType
+from mipengine.attrdict import AttrDict
+from mipengine.datatypes import DType
 
 __all__ = [
     "DType",

--- a/mipengine/algorithms/algorithm.py
+++ b/mipengine/algorithms/algorithm.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
@@ -123,10 +124,17 @@ class Algorithm(ABC):
         """
         return True
 
-    @staticmethod
-    @abstractmethod
-    def get_specification() -> AlgorithmSpecification:
-        pass
+    @classmethod
+    def get_specification(cls) -> AlgorithmSpecification:
+        """Returns the algorithm specs object
+
+        Algorithm specs are read from a json file placed in the same folder as
+        the algorithm implementation file, i.e. the file where `Algorithm` is
+        subclassed. The json file contents must map to the
+        `AlgorithmSpecification` structure.
+        """
+        file = Path(__file__).parent / f"{cls.algname}.json"
+        return AlgorithmSpecification.parse_file(file)
 
     @abstractmethod
     def run(self, engine, data, metadata):

--- a/mipengine/algorithms/anova.json
+++ b/mipengine/algorithms/anova.json
@@ -1,0 +1,48 @@
+{
+    "name": "anova",
+    "desc": "Test the difference in the means of the dependent variable between two or more groups, when there are two independent covariates.",
+    "label": "Two-way ANOVA",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "Two nominal variables.",
+            "types": [
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "sstype": {
+            "label": "sstype",
+            "desc": "Type of sum of squares to use. It can be 1 or 2.",
+            "types": [
+                "int"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 2,
+            "min": 1,
+            "max": 2
+        }
+    }
+}

--- a/mipengine/algorithms/anova.py
+++ b/mipengine/algorithms/anova.py
@@ -5,13 +5,6 @@ import numpy as np
 import scipy.stats as st
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.linear_regression import LinearRegression
 from mipengine.algorithms.preprocessing import FormulaTransformer
@@ -28,45 +21,6 @@ class AnovaResult(BaseModel):
 
 
 class AnovaTwoWay(Algorithm, algname="anova"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Test the difference in the means of the dependent variable between two or more groups, when there are two independent covariates.",
-            label="Two-way ANOVA",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="Two nominal variables.",
-                    types=[InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "sstype": ParameterSpecification(
-                    label="sstype",
-                    desc="Type of sum of squares to use. It can be 1 or 2.",
-                    types=[ParameterType.INT],
-                    notblank=True,
-                    multiple=False,
-                    default="2",
-                    min=1,
-                    max=2,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.y, self.variables.x]
 

--- a/mipengine/algorithms/anova_oneway.json
+++ b/mipengine/algorithms/anova_oneway.json
@@ -1,0 +1,34 @@
+{
+    "name": "anova_oneway",
+    "desc": "Test the difference in the means of the dependent variable between two or more groups, when there is a single independent covariate.",
+    "label": "One-way ANOVA",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique continuous variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariate (independent)",
+            "desc": "A unique nominal variable.",
+            "types": [
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": false
+        }
+    }
+}

--- a/mipengine/algorithms/anova_oneway.py
+++ b/mipengine/algorithms/anova_oneway.py
@@ -3,11 +3,6 @@ from typing import TypeVar
 import pandas as pd
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.exceptions import BadUserInput
@@ -27,33 +22,6 @@ class AnovaResult(BaseModel):
 
 
 class AnovaOneWayAlgorithm(Algorithm, algname="anova_oneway"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Test the difference in the means of the dependent variable between two or more groups, when there is a single independent covariate.",
-            label="One-way ANOVA",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariate (independent)",
-                    desc="A unique nominal variable.",
-                    types=[InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique continuous variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/descriptive_stats.json
+++ b/mipengine/algorithms/descriptive_stats.json
@@ -1,0 +1,38 @@
+{
+    "name": "descriptive_stats",
+    "desc": "Descriptive statistics",
+    "label": "Descriptive statistics",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "y",
+            "desc": "y",
+            "types": [
+                "int",
+                "real",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        },
+        "x": {
+            "label": "x",
+            "desc": "x",
+            "types": [
+                "int",
+                "real",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": false,
+            "multiple": true
+        }
+    }
+}

--- a/mipengine/algorithms/descriptive_stats.py
+++ b/mipengine/algorithms/descriptive_stats.py
@@ -36,11 +36,6 @@ import numpy
 import pandas as pd
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import MIN_ROW_COUNT
@@ -95,33 +90,6 @@ class Result(BaseModel):
 
 
 class DescriptiveStatisticsAlgorithm(Algorithm, algname="descriptive_stats"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Descriptive statistics",
-            label="Descriptive statistics",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="x",
-                    desc="x",
-                    types=[InputDataType.INT, InputDataType.REAL, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=False,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="y",
-                    desc="y",
-                    types=[InputDataType.INT, InputDataType.REAL, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-            ),
-        )
-
     def get_variable_groups(self):
         xvars = self.variables.x
         yvars = self.variables.y  # or []

--- a/mipengine/algorithms/linear_regression.json
+++ b/mipengine/algorithms/linear_regression.json
@@ -1,0 +1,35 @@
+{
+    "name": "linear_regression",
+    "desc": "Statistical method that models the relationship between a dependent variable and one or more independent variables by fitting a linear model to the observed data by ordinary least squares (OLS).",
+    "label": "Linear Regression",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    }
+}

--- a/mipengine/algorithms/linear_regression.py
+++ b/mipengine/algorithms/linear_regression.py
@@ -4,11 +4,6 @@ import numpy
 import scipy.stats as stats
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.algorithms.preprocessing import DummyEncoder
@@ -46,33 +41,6 @@ class LinearRegressionResult(BaseModel):
 
 
 class LinearRegressionAlgorithm(Algorithm, algname="linear_regression"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Statistical method that models the relationship between a dependent variable and one or more independent variables by fitting a linear model to the observed data by ordinary least squares (OLS).",
-            label="Linear Regression",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/linear_regression_cv.json
+++ b/mipengine/algorithms/linear_regression_cv.json
@@ -1,0 +1,49 @@
+{
+    "name": "linear_regression_cv",
+    "desc": "Method used to evaluate the performance of a linear regression model. It involves splitting the data into training and validation sets and testing the model's ability to generalize to new data by using the validation set.",
+    "label": "Linear Regression Cross-validation",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "n_splits": {
+            "label": "Number of splits",
+            "desc": "Number of splits for cross-validation.",
+            "types": [
+                "int"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 5,
+            "min": 2,
+            "max": 20
+        }
+    }
+}

--- a/mipengine/algorithms/linear_regression_cv.py
+++ b/mipengine/algorithms/linear_regression_cv.py
@@ -4,13 +4,6 @@ from typing import NamedTuple
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.linear_regression import LinearRegression
 from mipengine.algorithms.preprocessing import DummyEncoder
@@ -33,45 +26,6 @@ class CVLinearRegressionResult(BaseModel):
 
 
 class LinearRegressionCVAlgorithm(Algorithm, algname="linear_regression_cv"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Method used to evaluate the performance of a linear regression model. It involves splitting the data into training and validation sets and testing the model's ability to generalize to new data by using the validation set.",
-            label="Linear Regression Cross-validation",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "n_splits": ParameterSpecification(
-                    label="Number of splits",
-                    desc="Number of splits for cross-validation.",
-                    types=[ParameterType.INT],
-                    notblank=True,
-                    multiple=False,
-                    default=5,
-                    min=2,
-                    max=20,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/linear_regression_longitudinal.json
+++ b/mipengine/algorithms/linear_regression_longitudinal.json
@@ -1,0 +1,91 @@
+{
+    "name": "linear_regression_longitudinal",
+    "desc": "Linear Regression for longitudinal data. The user selects a pair of visits and a strategy for each variable and covariate. A non-longitudinal dataset is then created from these parameters and an ordinary Linear Regression is run.",
+    "label": "Linear Regression for longitudinal data",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "visit1": {
+            "label": "1st visit",
+            "desc": "Can be chosen among BL (baseline), FL1 (follow-up1), FL2, FL3 or FL4.",
+            "types": [
+                "text"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "enums": {
+                "type": "fixed_var_CDE_enums",
+                "source": [
+                    "visitid"
+                ]
+            }
+        },
+        "visit2": {
+            "label": "2nd visit",
+            "desc": "Can be chosen among BL (baseline), FL1 (follow-up1), FL2, FL3 or FL4.",
+            "types": [
+                "text"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "enums": {
+                "type": "fixed_var_CDE_enums",
+                "source": [
+                    "visitid"
+                ]
+            }
+        },
+        "strategies": {
+            "label": "Strategies",
+            "desc": " The strategies can be: 'diff': Compute the difference between the second and first visits, 'first': Keep value on first visit, 'second': Keep value on second visit.",
+            "types": [
+                "dict"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "dict_keys_enums": {
+                "type": "input_var_names",
+                "source": [
+                    "x",
+                    "y"
+                ]
+            },
+            "dict_values_enums": {
+                "type": "list",
+                "source": [
+                    "diff",
+                    "first",
+                    "second"
+                ]
+            }
+        }
+    }
+}

--- a/mipengine/algorithms/linear_regression_longitudinal.py
+++ b/mipengine/algorithms/linear_regression_longitudinal.py
@@ -1,12 +1,3 @@
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.linear_regression import LinearRegression
 from mipengine.algorithms.linear_regression import LinearRegressionResult
@@ -16,68 +7,6 @@ from mipengine.algorithms.preprocessing import relation_to_vector
 
 
 class LinearRegressionLongitudinal(Algorithm, algname="linear_regression_longitudinal"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Linear Regression for longitudinal data. The user selects a pair of visits and a strategy for each variable and covariate. A non-longitudinal dataset is then created from these parameters and an ordinary Linear Regression is run.",
-            label="Linear Regression for longitudinal data",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "visit1": ParameterSpecification(
-                    label="1st visit",
-                    desc="Can be chosen among BL (baseline), FL1 (follow-up1), FL2, FL3 or FL4.",
-                    types=[ParameterType.TEXT],
-                    notblank=True,
-                    multiple=False,
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.FIXED_VAR_CDE_ENUMS, source=["visitid"]
-                    ),
-                ),
-                "visit2": ParameterSpecification(
-                    label="2nd visit",
-                    desc="Can be chosen among BL (baseline), FL1 (follow-up1), FL2, FL3 or FL4.",
-                    types=[ParameterType.TEXT],
-                    notblank=True,
-                    multiple=False,
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.FIXED_VAR_CDE_ENUMS, source=["visitid"]
-                    ),
-                ),
-                "strategies": ParameterSpecification(
-                    label="Strategies",
-                    desc=" The strategies can be: 'diff': Compute the difference between the second and first visits, 'first': Keep value on first visit, 'second': Keep value on second visit.",
-                    types=[ParameterType.DICT],
-                    notblank=True,
-                    multiple=False,
-                    dict_keys_enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUT_VAR_NAMES, source=["x", "y"]
-                    ),
-                    dict_values_enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.LIST, source=["diff", "first", "second"]
-                    ),
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         xvars = self.variables.x
         yvars = self.variables.y

--- a/mipengine/algorithms/logistic_regression.json
+++ b/mipengine/algorithms/logistic_regression.json
@@ -1,0 +1,52 @@
+{
+    "name": "logistic_regression",
+    "desc": "Statistical method. that models the relationship between a dependent binary variable and one or more independent variables by fitting a binary logistic curve to the observed data.",
+    "label": "Logistic Regression",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique nominal variable. The variable is converted to binary by assigning 1 to the positive class and 0 to all other classes. ",
+            "types": [
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "positive_class": {
+            "label": "Positive class",
+            "desc": "Positive class of y. All other classes are considered negative.",
+            "types": [
+                "text",
+                "int"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "enums": {
+                "type": "input_var_CDE_enums",
+                "source": ["y"]
+            }
+        }
+    }
+}

--- a/mipengine/algorithms/logistic_regression.py
+++ b/mipengine/algorithms/logistic_regression.py
@@ -5,15 +5,6 @@ import scipy.stats as stats
 from pydantic import BaseModel
 from scipy.special import xlogy
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.algorithms.preprocessing import DummyEncoder
@@ -31,46 +22,6 @@ ALPHA = 0.05  # alpha level for coefficient confidence intervals
 
 
 class LogisticRegressionAlgorithm(Algorithm, algname="logistic_regression"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Statistical method. that models the relationship between a dependent binary variable and one or more independent variables by fitting a binary logistic curve to the observed data.",
-            label="Logistic Regression",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique nominal variable. The variable is converted to binary by assigning 1 to the positive class and 0 to all other classes. ",
-                    types=[InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "positive_class": ParameterSpecification(
-                    label="Positive class",
-                    desc="Positive class of y. All other classes are considered negative.",
-                    types=[ParameterType.TEXT, ParameterType.INT],
-                    notblank=True,
-                    multiple=False,
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS,
-                        source=["y"],
-                    ),
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/logistic_regression_cv.json
+++ b/mipengine/algorithms/logistic_regression_cv.json
@@ -1,0 +1,64 @@
+{
+    "name": "logistic_regression_cv",
+    "desc": "Method used to evaluate the performance of a logistic regression model. It involves splitting the data into training and validation sets and testing the model's ability to generalize to new data by using the validation set.",
+    "label": "Logistic Regression Cross-validation",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique nominal variable. The variable is converted to binary by assigning 1 to the positive class and 0 to all other classes. ",
+            "types": [
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariates (independent)",
+            "desc": "One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "positive_class": {
+            "label": "Positive class",
+            "desc": "Positive class of y. All other classes are considered negative.",
+            "types": [
+                "text",
+                "int"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "enums": {
+                "type": "input_var_CDE_enums",
+                "source": ["y"]
+            }
+        },
+        "n_splits": {
+            "label": "Number of splits",
+            "desc": "Number of splits for cross-validation.",
+            "types": [
+                "int"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 5,
+            "min": 2,
+            "max": 20
+        }
+    }
+}

--- a/mipengine/algorithms/logistic_regression_cv.py
+++ b/mipengine/algorithms/logistic_regression_cv.py
@@ -5,15 +5,6 @@ from typing import Optional
 import sklearn.metrics as skm
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.logistic_regression import LogisticRegression
 from mipengine.algorithms.metrics import compute_classification_metrics
@@ -25,56 +16,6 @@ from mipengine.algorithms.preprocessing import LabelBinarizer
 
 
 class LogisticRegressionCVAlgorithm(Algorithm, algname="logistic_regression_cv"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Method used to evaluate the performance of a logistic regression model. It involves splitting the data into training and validation sets and testing the model's ability to generalize to new data by using the validation set.",
-            label="Logistic Regression Cross-validation",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                x=InputDataSpecification(
-                    label="Covariates (independent)",
-                    desc="One or more variables. Can be numerical or nominal. For nominal variables dummy encoding is used.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique nominal variable. The variable is converted to binary by assigning 1 to the positive class and 0 to all other classes. ",
-                    types=[InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "positive_class": ParameterSpecification(
-                    label="Positive class",
-                    desc="Positive class of y. All other classes are considered negative.",
-                    types=[ParameterType.TEXT, ParameterType.INT],
-                    notblank=True,
-                    multiple=False,
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.INPUT_VAR_CDE_ENUMS,
-                        source=["y"],
-                    ),
-                ),
-                "n_splits": ParameterSpecification(
-                    label="Number of splits",
-                    desc="Number of splits for cross-validation.",
-                    types=[ParameterType.INT],
-                    notblank=True,
-                    multiple=False,
-                    default=5,
-                    min=2,
-                    max=20,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/multiple_histograms.json
+++ b/mipengine/algorithms/multiple_histograms.json
@@ -1,0 +1,50 @@
+{
+    "name": "multiple_histograms",
+    "desc": "Multiple Histograms",
+    "label": "Multiple Histograms",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "y",
+            "desc": "Variable to distribute among bins.",
+            "types": [
+                "real",
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "numerical",
+                "nominal"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "x",
+            "desc": "Nominal variable for grouping bins.",
+            "types": [
+                "int",
+                "text"
+            ],
+            "stattypes": [
+                "nominal"
+            ],
+            "notblank": false,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "bins": {
+            "label": "Number of bins",
+            "desc": "Number of bins",
+            "types": [
+                "int"
+            ],
+            "notblank": false,
+            "multiple": false,
+            "default": 20,
+            "min": 1,
+            "max": 100
+        }
+    }
+}

--- a/mipengine/algorithms/multiple_histograms.py
+++ b/mipengine/algorithms/multiple_histograms.py
@@ -6,13 +6,6 @@ from typing import Union
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import MIN_ROW_COUNT
@@ -39,45 +32,6 @@ class HistogramResult1(BaseModel):
 
 
 class MultipleHistogramsAlgorithm(Algorithm, algname="multiple_histograms"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Multiple Histograms",
-            label="Multiple Histograms",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="y",
-                    desc="Variable to distribute among bins.",
-                    types=[InputDataType.REAL, InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NUMERICAL, InputDataStatType.NOMINAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-                x=InputDataSpecification(
-                    label="x",
-                    desc="Nominal variable for grouping bins.",
-                    types=[InputDataType.INT, InputDataType.TEXT],
-                    stattypes=[InputDataStatType.NOMINAL],
-                    notblank=False,
-                    multiple=True,
-                ),
-            ),
-            parameters={
-                "bins": ParameterSpecification(
-                    label="Number of bins",
-                    desc="Number of bins",
-                    types=[ParameterType.INT],
-                    notblank=False,
-                    multiple=False,
-                    default=20,
-                    min=1,
-                    max=100,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.y + self.variables.x]
 

--- a/mipengine/algorithms/pca.json
+++ b/mipengine/algorithms/pca.json
@@ -1,0 +1,21 @@
+{
+    "name": "pca",
+    "desc": "Computes the principal components of a set of correlated variables. The principal components can then be used to represent the original data with reduced dimensions.",
+    "label": "Principal Component Analysis (PCA)",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variables",
+            "desc": "A list of numerical variables.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": true
+        }
+    }
+}

--- a/mipengine/algorithms/pca.py
+++ b/mipengine/algorithms/pca.py
@@ -4,11 +4,6 @@ from typing import TypeVar
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import relation
@@ -26,25 +21,6 @@ class PCAResult(BaseModel):
 
 
 class PCAAlgorithm(Algorithm, algname="pca"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Computes the principal components of a set of correlated variables. The principal components can then be used to represent the original data with reduced dimensions.",
-            label="Principal Component Analysis (PCA)",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="Variables",
-                    desc="A list of numerical variables.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-            ),
-        )
-
     def get_variable_groups(self):
         return [self.variables.y]
 

--- a/mipengine/algorithms/pearson_correlation.json
+++ b/mipengine/algorithms/pearson_correlation.json
@@ -1,0 +1,48 @@
+{
+    "name": "pearson_correlation",
+    "desc": "Measure the linear relationship between two continuous variables. It calculates the correlation coefficient (range: -1 to 1). The correlation matrix will be computed between all possible pairs of variables and covariates. Leaving covariates empty is equivalent to having covariates = variables.",
+    "label": "Pearson Correlation Matrix",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variables",
+            "desc": "Nuerical variables on x axis of correlation matrix.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": true
+        },
+        "x": {
+            "label": "Covariates (optional)",
+            "desc": "Nuerical variables on y axis of correlation matrix.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": false,
+            "multiple": true
+        }
+    },
+    "parameters": {
+        "alpha": {
+            "label": "Confidence level",
+            "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
+            "types": [
+                "real"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 0.95,
+            "min": 0.0,
+            "max": 1.0
+        }
+    }
+}

--- a/mipengine/algorithms/pearson_correlation.py
+++ b/mipengine/algorithms/pearson_correlation.py
@@ -3,13 +3,6 @@ from typing import TypeVar
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import literal
@@ -29,45 +22,6 @@ class PearsonResult(BaseModel):
 
 
 class PearsonCorrelationAlgorithm(Algorithm, algname="pearson_correlation"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Measure the linear relationship between two continuous variables. It calculates the correlation coefficient (range: -1 to 1). The correlation matrix will be computed between all possible pairs of variables and covariates. Leaving covariates empty is equivalent to having covariates = variables.",
-            label="Pearson Correlation Matrix",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="Variables",
-                    desc="Nuerical variables on x axis of correlation matrix.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=True,
-                ),
-                x=InputDataSpecification(
-                    label="Covariates (optional)",
-                    desc="Nuerical variables on y axis of correlation matrix.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=False,
-                    multiple=True,
-                ),
-            ),
-            parameters={
-                "alpha": ParameterSpecification(
-                    label="Confidence level",
-                    desc="The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-                    types=[ParameterType.REAL],
-                    notblank=True,
-                    multiple=False,
-                    default=0.95,
-                    min=0.0,
-                    max=1.0,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         if self.variables.x:
             variable_groups = [self.variables.x, self.variables.y]

--- a/mipengine/algorithms/ttest_independent.json
+++ b/mipengine/algorithms/ttest_independent.json
@@ -1,0 +1,66 @@
+{
+    "name": "ttest_independent",
+    "desc": "Test the difference in means between two independent groups. It assumes that the two groups have equal variances and are independently sampled from normal distributions.",
+    "label": "T-Test Independent",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariate (independent)",
+            "desc": "A unique continuous variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        }
+    },
+    "parameters": {
+        "alt_hypothesis": {
+            "label": "Alternative Hypothesis",
+            "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
+            "types": [
+                "text"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": "two-sided",
+            "enums": {
+                "type": "list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            }
+        },
+        "confidence_lvl": {
+            "label": "Confidence level",
+            "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
+            "types": [
+                "real"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 0.95,
+            "min": 0.0,
+            "max": 1.0
+        }
+    }
+}

--- a/mipengine/algorithms/ttest_independent.py
+++ b/mipengine/algorithms/ttest_independent.py
@@ -1,15 +1,6 @@
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import literal
@@ -31,57 +22,6 @@ class TtestResult(BaseModel):
 
 
 class IndependentTTestAlgorithm(Algorithm, algname="ttest_independent"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Test the difference in means between two independent groups. It assumes that the two groups have equal variances and are independently sampled from normal distributions.",
-            label="T-Test Independent",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-                x=InputDataSpecification(
-                    label="Covariate (independent)",
-                    desc="A unique continuous variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "alt_hypothesis": ParameterSpecification(
-                    label="Alternative Hypothesis",
-                    desc="The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
-                    types=[ParameterType.TEXT],
-                    notblank=True,
-                    multiple=False,
-                    default="two-sided",
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.LIST,
-                        source=["two-sided", "less", "greater"],
-                    ),
-                ),
-                "confidence_lvl": ParameterSpecification(
-                    label="Confidence level",
-                    desc="The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-                    types=[ParameterType.REAL],
-                    notblank=True,
-                    multiple=False,
-                    default=0.95,
-                    min=0.0,
-                    max=1.0,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 

--- a/mipengine/algorithms/ttest_onesample.json
+++ b/mipengine/algorithms/ttest_onesample.json
@@ -1,0 +1,65 @@
+{
+    "name": "ttest_onesample",
+    "desc": "Test the difference in mean of a single sample with a population mean. It assumes that the sample is drawn from a normal distribution.",
+    "label": "T-Test One-Sample",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        }
+    },
+    "parameters": {
+        "alt_hypothesis": {
+            "label": "Alternative Hypothesis",
+            "desc": "The alternative hypothesis to the null, returning specifically whether the result is less than, greater than, or .",
+            "types": [
+                "text"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": "two-sided",
+            "enums": {
+                "type": "list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            }
+        },
+        "alpha": {
+            "label": "Confidence level",
+            "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
+            "types": [
+                "real"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 0.95,
+            "min": 0.0,
+            "max": 1.0
+        },
+        "mu": {
+            "label": "Population mean",
+            "desc": "The population mean, if it is known, else it defaults to 0.",
+            "types": [
+                "real"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 0.0,
+            "min": -10.0,
+            "max": 10.0
+        }
+    }
+}

--- a/mipengine/algorithms/ttest_onesample.py
+++ b/mipengine/algorithms/ttest_onesample.py
@@ -1,15 +1,6 @@
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import literal
@@ -33,59 +24,6 @@ class TtestResult(BaseModel):
 
 
 class OnesampleTTestAlgorithm(Algorithm, algname="ttest_onesample"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Test the difference in mean of a single sample with a population mean. It assumes that the sample is drawn from a normal distribution.",
-            label="T-Test One-Sample",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="Variable",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "alt_hypothesis": ParameterSpecification(
-                    label="Alternative Hypothesis",
-                    desc="The alternative hypothesis to the null, returning specifically whether the result is less than, greater than, or .",
-                    types=[ParameterType.TEXT],
-                    notblank=True,
-                    multiple=False,
-                    default="two-sided",
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.LIST,
-                        source=["two-sided", "less", "greater"],
-                    ),
-                ),
-                "alpha": ParameterSpecification(
-                    label="Confidence level",
-                    desc="The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-                    types=[ParameterType.REAL],
-                    notblank=True,
-                    multiple=False,
-                    default=0.95,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "mu": ParameterSpecification(
-                    label="Population mean",
-                    desc="The population mean, if it is known, else it defaults to 0.",
-                    types=[ParameterType.REAL],
-                    notblank=True,
-                    multiple=False,
-                    default=0.0,
-                    min=-10,
-                    max=10,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.y]
 

--- a/mipengine/algorithms/ttest_paired.json
+++ b/mipengine/algorithms/ttest_paired.json
@@ -1,0 +1,66 @@
+{
+    "name": "ttest_paired",
+    "desc": "Test the difference in means between two related groups. It is commonly used when the same subjects are measured twice, such as before and after a treatment.",
+    "label": "T-Test paired",
+    "enabled": true,
+    "inputdata": {
+        "y": {
+            "label": "Variable (dependent)",
+            "desc": "A unique numerical variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        },
+        "x": {
+            "label": "Covariate (independent)",
+            "desc": "A unique continuous variable.",
+            "types": [
+                "real",
+                "int"
+            ],
+            "stattypes": [
+                "numerical"
+            ],
+            "notblank": true,
+            "multiple": false
+        }
+    },
+    "parameters": {
+        "alt_hypothesis": {
+            "label": "Alternative Hypothesis",
+            "desc": "The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
+            "types": [
+                "text"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": "two-sided",
+            "enums": {
+                "type": "list",
+                "source": [
+                    "two-sided",
+                    "less",
+                    "greater"
+                ]
+            }
+        },
+        "alpha": {
+            "label": "Confidence level",
+            "desc": "The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
+            "types": [
+                "real"
+            ],
+            "notblank": true,
+            "multiple": false,
+            "default": 0.95,
+            "min": 0.0,
+            "max": 1.0
+        }
+    }
+}

--- a/mipengine/algorithms/ttest_paired.py
+++ b/mipengine/algorithms/ttest_paired.py
@@ -1,15 +1,6 @@
 import numpy
 from pydantic import BaseModel
 
-from mipengine.algorithm_specification import AlgorithmSpecification
-from mipengine.algorithm_specification import InputDataSpecification
-from mipengine.algorithm_specification import InputDataSpecifications
-from mipengine.algorithm_specification import InputDataStatType
-from mipengine.algorithm_specification import InputDataType
-from mipengine.algorithm_specification import ParameterEnumSpecification
-from mipengine.algorithm_specification import ParameterEnumType
-from mipengine.algorithm_specification import ParameterSpecification
-from mipengine.algorithm_specification import ParameterType
 from mipengine.algorithms.algorithm import Algorithm
 from mipengine.algorithms.helpers import get_transfer_data
 from mipengine.udfgen import literal
@@ -31,57 +22,6 @@ class TtestResult(BaseModel):
 
 
 class PairedTTestAlgorithm(Algorithm, algname="ttest_paired"):
-    @classmethod
-    def get_specification(cls):
-        return AlgorithmSpecification(
-            name=cls.algname,
-            desc="Test the difference in means between two related groups. It is commonly used when the same subjects are measured twice, such as before and after a treatment.",
-            label="T-Test paired",
-            enabled=True,
-            inputdata=InputDataSpecifications(
-                y=InputDataSpecification(
-                    label="Variable (dependent)",
-                    desc="A unique numerical variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-                x=InputDataSpecification(
-                    label="Covariate (independent)",
-                    desc="A unique continuous variable.",
-                    types=[InputDataType.REAL, InputDataType.INT],
-                    stattypes=[InputDataStatType.NUMERICAL],
-                    notblank=True,
-                    multiple=False,
-                ),
-            ),
-            parameters={
-                "alt_hypothesis": ParameterSpecification(
-                    label="Alternative Hypothesis",
-                    desc="The alternative hypothesis to the null, returning specifically whether measure 1 is different to measure 2, measure 1 greater than measure 2, and measure 1 less than measure 2 respectively.",
-                    types=[ParameterType.TEXT],
-                    notblank=True,
-                    multiple=False,
-                    default="two-sided",
-                    enums=ParameterEnumSpecification(
-                        type=ParameterEnumType.LIST,
-                        source=["two-sided", "less", "greater"],
-                    ),
-                ),
-                "alpha": ParameterSpecification(
-                    label="Confidence level",
-                    desc="The confidence level α used in the calculation of the confidence intervals for the correlation coefficients.",
-                    types=[ParameterType.REAL],
-                    notblank=True,
-                    multiple=False,
-                    default=0.95,
-                    min=0.0,
-                    max=1.0,
-                ),
-            },
-        )
-
     def get_variable_groups(self):
         return [self.variables.x, self.variables.y]
 


### PR DESCRIPTION
- Algorithm spec files are generated from the corresponding `AlgorithmSpecification` objects and placed in mipengine/algorithms
- `get_specification` is implemented in parent class `Algorithm` where it reads and parses the contents of mipengine/algorithms/<ALGNAME>.json