### PR TITLE
Fix the bug of kubernetes setting incorrectly the max memory of the monetdb.

### DIFF
--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -34,6 +34,8 @@ spec:
           value: {{ .Values.log_level }}
         - name: MONETDB_NCLIENTS
           value: {{ mul .Values.max_concurrent_experiments .Values.localnodes | quote }}
+        - name: MAX_MEMORY
+          value: {{ mul .Values.db.max_memory 1048576 | quote }} # We provide mb but memmaxsize of monetdb is in bytes
         - name: SOFT_RESTART_MEMORY_LIMIT
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
         - name: HARD_RESTART_MEMORY_LIMIT

--- a/kubernetes/templates/mipengine-globalnode.yaml
+++ b/kubernetes/templates/mipengine-globalnode.yaml
@@ -34,11 +34,11 @@ spec:
           value: {{ .Values.log_level }}
         - name: MONETDB_NCLIENTS
           value: {{ mul .Values.max_concurrent_experiments .Values.localnodes | quote }}
-        - name: MAX_MEMORY
-          value: {{ mul .Values.db.max_memory 1048576 | quote }} # We provide mb but memmaxsize of monetdb is in bytes
-        - name: SOFT_RESTART_MEMORY_LIMIT
+        - name: MAX_MEMORY   # Value in bytes
+          value: {{ mul .Values.db.max_memory 1048576 | quote }} # Conversion to bytes
+        - name: SOFT_RESTART_MEMORY_LIMIT   # Value in megabytes
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
-        - name: HARD_RESTART_MEMORY_LIMIT
+        - name: HARD_RESTART_MEMORY_LIMIT   # Value in megabytes
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_hard_memory_limit) 100 | quote }}
         ports:
           - containerPort: 50000

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -44,6 +44,8 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}
+        - name: MAX_MEMORY
+          value: {{ mul .Values.db.max_memory 1048576 | quote }} # We provide mb but memmaxsize of monetdb is in bytes
         - name: SOFT_RESTART_MEMORY_LIMIT
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
         - name: HARD_RESTART_MEMORY_LIMIT

--- a/kubernetes/templates/mipengine-localnode.yaml
+++ b/kubernetes/templates/mipengine-localnode.yaml
@@ -44,13 +44,14 @@ spec:
         env:
         - name: LOG_LEVEL
           value: {{ .Values.log_level }}
-        - name: MAX_MEMORY
-          value: {{ mul .Values.db.max_memory 1048576 | quote }} # We provide mb but memmaxsize of monetdb is in bytes
-        - name: SOFT_RESTART_MEMORY_LIMIT
+        - name: MONETDB_NCLIENTS
+          value: {{ mul .Values.max_concurrent_experiments .Values.localnodes | quote }}
+        - name: MAX_MEMORY   # Value in bytes
+          value: {{ mul .Values.db.max_memory 1048576 | quote }} # Conversion to bytes
+        - name: SOFT_RESTART_MEMORY_LIMIT   # Value in megabytes
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_soft_memory_limit) 100 | quote }}
-        - name: HARD_RESTART_MEMORY_LIMIT
+        - name: HARD_RESTART_MEMORY_LIMIT   # Value in megabytes
           value: {{ div  (mul .Values.db.max_memory .Values.db.percentage_hard_memory_limit) 100 | quote }}
-
         ports:
           - containerPort: 50000
         volumeMounts:

--- a/monetdb/Dockerfile
+++ b/monetdb/Dockerfile
@@ -86,6 +86,12 @@ VOLUME $MONETDB_STORAGE
 ENV MONIT_CONFIG_FOLDER=/home/monit
 RUN mkdir $MONIT_CONFIG_FOLDER
 
+# MAX monetdb memory in bytes
+ENV MAX_MEMORY=2147483648
+# Soft monetdb restart memory limit in megabytes
+ENV SOFT_RESTART_MEMORY_LIMIT=1200
+# Hard monetdb restart memory limit in megabytes
+ENV HARD_RESTART_MEMORY_LIMIT=1600
 
 WORKDIR /home
 CMD ["sh", "-c", "/home/bootstrap.sh; tail -fn +1 $MONETDB_STORAGE/merovingian.log -fn +1 $MONIT_CONFIG_FOLDER/monit.log"]

--- a/monetdb/bootstrap.sh
+++ b/monetdb/bootstrap.sh
@@ -17,6 +17,8 @@ then
   # Create the database instance
   monetdb create db
   monetdb set nclients=$MONETDB_NCLIENTS db
+  monetdb set vmmaxsize=$MAX_MEMORY db
+  monetdb set memmaxsize=$MAX_MEMORY db
   monetdb set embedpy3=true db
   # 'monetdb set mal_for_all=yes db' is needed to be able to access tables on a remote database with user that is not the master user.
   monetdb set mal_for_all=yes db
@@ -40,6 +42,8 @@ else
 
   echo 'Starting the already existing database...'
   monetdbd start $MONETDB_STORAGE
+  monetdb set vmmaxsize=$MAX_MEMORY db
+  monetdb set memmaxsize=$MAX_MEMORY db
   monetdb set nclients=$MONETDB_NCLIENTS db
   monetdb set mal_for_all=yes db
   monetdb start db

--- a/tasks.py
+++ b/tasks.py
@@ -331,7 +331,7 @@ def create_monetdb(
             f"Starting container {container_name} on ports {container_ports}...",
             Level.HEADER,
         )
-        cmd = f"""docker run -d -P -p {container_ports} -e SOFT_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.7} -e HARD_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.85}  -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
+        cmd = f"""docker run -d -P -p {container_ports} -e SOFT_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.7} -e HARD_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.85}  -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -e MAX_MEMORY={monetdb_memory_limit} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
         run(c, cmd)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -331,7 +331,7 @@ def create_monetdb(
             f"Starting container {container_name} on ports {container_ports}...",
             Level.HEADER,
         )
-        cmd = f"""docker run -d -P -p {container_ports} -e SOFT_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.7} -e HARD_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.85}  -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -e MAX_MEMORY={monetdb_memory_limit} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
+        cmd = f"""docker run -d -P -p {container_ports} -e SOFT_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.7} -e HARD_RESTART_MEMORY_LIMIT={monetdb_memory_limit * 0.85}  -e LOG_LEVEL={log_level} {monetdb_nclient_env_var} -e MAX_MEMORY={monetdb_memory_limit*1048576} {monetdb_nclient_env_var} -v {udfio_full_path}:/home/udflib/udfio.py -v {TEST_DATA_FOLDER}:{TEST_DATA_FOLDER} --name {container_name} --memory={monetdb_memory_limit}m {image}"""
         run(c, cmd)
 
 


### PR DESCRIPTION
Added a Env on the monetdb in order to override the given memory give to the container.

To avoid the bug of kubernetes  setting incorrectly the memory of the monetdb.