### PR TITLE
Removed unneeded parameter from `validate_algorithm_request`.

### DIFF
--- a/mipengine/controller/api/validator.py
+++ b/mipengine/controller/api/validator.py
@@ -32,7 +32,6 @@ class BadRequest(Exception):
 def validate_algorithm_request(
     algorithm_name: str,
     algorithm_request_dto: AlgorithmRequestDTO,
-    available_datasets_per_data_model: Dict[str, List[str]],
     algorithms_specs: Dict[str, AlgorithmSpecification],
     node_landscape_aggregator: NodeLandscapeAggregator,
     smpc_enabled: bool,
@@ -42,7 +41,6 @@ def validate_algorithm_request(
     _validate_algorithm_request_body(
         algorithm_request_dto=algorithm_request_dto,
         algorithm_specs=algorithm_specs,
-        available_datasets_per_data_model=available_datasets_per_data_model,
         node_landscape_aggregator=node_landscape_aggregator,
         smpc_enabled=smpc_enabled,
         smpc_optional=smpc_optional,
@@ -60,11 +58,13 @@ def _get_algorithm_specs(
 def _validate_algorithm_request_body(
     algorithm_request_dto: AlgorithmRequestDTO,
     algorithm_specs: AlgorithmSpecification,
-    available_datasets_per_data_model: Dict[str, List[str]],
     node_landscape_aggregator: NodeLandscapeAggregator,
     smpc_enabled: bool,
     smpc_optional: bool,
 ):
+    available_datasets_per_data_model = (
+        node_landscape_aggregator.get_all_available_datasets_per_data_model()
+    )
     _validate_data_model(
         requested_data_model=algorithm_request_dto.inputdata.data_model,
         available_datasets_per_data_model=available_datasets_per_data_model,

--- a/mipengine/controller/controller.py
+++ b/mipengine/controller/controller.py
@@ -427,7 +427,6 @@ class Controller:
         validate_algorithm_request(
             algorithm_name=algorithm_name,
             algorithm_request_dto=algorithm_request_dto,
-            available_datasets_per_data_model=available_datasets_per_data_model,
             algorithms_specs=algorithms_specifications,
             node_landscape_aggregator=self._node_landscape_aggregator,
             smpc_enabled=self._smpc_enabled,

--- a/tests/standalone_tests/test_validate_algorithm_request.py
+++ b/tests/standalone_tests/test_validate_algorithm_request.py
@@ -15,6 +15,7 @@ from mipengine.controller.api.validator import BadRequest
 from mipengine.controller.api.validator import validate_algorithm_request
 from mipengine.controller.node_landscape_aggregator import DataModelRegistry
 from mipengine.controller.node_landscape_aggregator import DataModelsCDES
+from mipengine.controller.node_landscape_aggregator import DatasetsLocations
 from mipengine.controller.node_landscape_aggregator import (
     InitializationParams as NodeLandscapeAggregatorInitParams,
 )
@@ -97,19 +98,19 @@ def node_landscape_aggregator():
     }
     _data_model_registry = DataModelRegistry(
         data_models_cdes=DataModelsCDES(data_models_cdes=data_models),
+        datasets_locations=DatasetsLocations(
+            datasets_locations={
+                "data_model_with_all_cde_types:0.1": {
+                    "sample_dataset1": "sample_node",
+                    "sample_dataset2": "sample_node",
+                },
+                "sample_data_model:0.1": {"sample_dataset": "sample_node"},
+            }
+        ),
     )
     nla._registries = _NLARegistries(data_model_registry=_data_model_registry)
 
     return nla
-
-
-@pytest.fixture()
-def available_datasets_per_data_model():
-    d = {
-        "data_model_with_all_cde_types:0.1": ["sample_dataset1", "sample_dataset2"],
-        "sample_data_model:0.1": ["sample_dataset"],
-    }
-    return d
 
 
 @pytest.fixture(scope="module")
@@ -616,14 +617,12 @@ def get_parametrization_list_success_cases():
 def test_validate_algorithm_success(
     algorithm_name,
     request_dto,
-    available_datasets_per_data_model,
     node_landscape_aggregator,
     algorithms_specs,
 ):
     validate_algorithm_request(
         algorithm_name=algorithm_name,
         algorithm_request_dto=request_dto,
-        available_datasets_per_data_model=available_datasets_per_data_model,
         algorithms_specs=algorithms_specs,
         node_landscape_aggregator=node_landscape_aggregator,
         smpc_enabled=False,
@@ -1021,7 +1020,6 @@ def test_validate_algorithm_exceptions(
     algorithm_name,
     request_dto,
     exception,
-    available_datasets_per_data_model,
     algorithms_specs,
     node_landscape_aggregator,
 ):
@@ -1030,7 +1028,6 @@ def test_validate_algorithm_exceptions(
         validate_algorithm_request(
             algorithm_name=algorithm_name,
             algorithm_request_dto=request_dto,
-            available_datasets_per_data_model=available_datasets_per_data_model,
             algorithms_specs=algorithms_specs,
             node_landscape_aggregator=node_landscape_aggregator,
             smpc_enabled=False,


### PR DESCRIPTION
The `available_datasets_per_data_model` parameter could be read from the `node_landscape_aggregator` so there is no need to pass it as well.