### PR TITLE
removed insert_data_to_table task

### DIFF
--- a/exareme2/node/tasks/tables.py
+++ b/exareme2/node/tasks/tables.py
@@ -85,4 +85,4 @@ def insert_data_to_table(
     values : List[List[Union[str, int, float, bool]]
         The data of the table to be inserted
     """
-    tables.insert_data_to_table(table_name, values)
+    return tables.insert_data_to_table(table_name, values)

--- a/exareme2/node/tasks/tables.py
+++ b/exareme2/node/tasks/tables.py
@@ -67,22 +67,3 @@ def create_table(
         schema_=schema,
         type_=TableType.NORMAL,
     ).json()
-
-
-# TODO: https://team-1617704806227.atlassian.net/browse/MIP-762
-@shared_task
-@initialise_logger
-def insert_data_to_table(
-    request_id: str, table_name: str, values: List[List[Union[str, int, float, bool]]]
-):
-    """
-    Parameters
-    ----------
-    request_id : str
-        The identifier for the logging
-    table_name : str
-        The name of the table
-    values : List[List[Union[str, int, float, bool]]
-        The data of the table to be inserted
-    """
-    return tables.insert_data_to_table(table_name, values)

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -560,24 +560,18 @@ def localnodetmp_db_cursor():
 
 
 def insert_data_to_db(
-    table_name: str,
-    table_values: List[List[Union[str, int, float]]],
-    db_port,
+    table_name: str, table_values: List[List[Union[str, int, float]]], db_cursor
 ):
     row_length = len(table_values[0])
     if all(len(row) != row_length for row in table_values):
         raise Exception("Not all rows have the same number of values")
 
-    # In order to achieve insertion with parameters we need to create query to the following format:
-    # INSERT INTO <table_name> VALUES (%s, %s), (%s, %s);
-    # The following variable 'values' create that specific str according to row_length and the amount of the rows.
     values = ", ".join(
         "(" + ", ".join("%s" for _ in range(row_length)) + ")" for _ in table_values
     )
     sql_clause = f"INSERT INTO {table_name} VALUES {values}"
 
-    cursor = _create_db_cursor(db_port)
-    cursor.execute(sql_clause, list(chain(*table_values)))
+    db_cursor.execute(sql_clause, list(chain(*table_values)))
 
 
 def _clean_db(cursor):

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 import subprocess
 import time
+from itertools import chain
 from os import path
 from pathlib import Path
 from typing import List
@@ -567,31 +568,16 @@ def insert_data_to_localnode(
     if all(len(row) != row_length for row in table_values):
         raise Exception("Not all rows have the same number of values")
 
-    # rows= ["(" + ",".join(map(str, sublist)) + ")" for sublist in table_values]
-    table_values = [
-        [item if item is not None else "None" for item in sublist]
-        for sublist in table_values
-    ]
-    rows = ["(" + ",".join(map(repr, sublist)) + ")" for sublist in table_values]
-
-    # rows = [str(tuple(sub)) for sub in table_values]
-    # rows = [item.replace('None', "'None'") for item in rows]
-
     # In order to achieve insertion with parameters we need to create query to the following format:
     # INSERT INTO <table_name> VALUES (%s, %s), (%s, %s);
     # The following variable 'values' create that specific str according to row_length and the amount of the rows.
-    # values = ", ".join(
-    #     "(" + ", ".join("%s" for _ in range(row_length)) + ")" for _ in table_values
-    # )
-
-    # sql_clause = f"INSERT INTO {table_name} VALUES {values}"
-    sql_clause = f"INSERT INTO {table_name} VALUES {', '.join(rows)}"
+    values = ", ".join(
+        "(" + ", ".join("%s" for _ in range(row_length)) + ")" for _ in table_values
+    )
+    sql_clause = f"INSERT INTO {table_name} VALUES {values}"
 
     cursor = _create_db_cursor(monetdb_localnode_port)
-    cursor.execute(sql_clause)
-    # breakpoint()
-    # with cursor(commit=True) as cur:
-    #     cursor.execute(sql_clause,list(chain(*table_values)))
+    cursor.execute(sql_clause, list(chain(*table_values)))
 
 
 def _clean_db(cursor):

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -558,23 +558,25 @@ def localnodetmp_db_cursor():
     return _create_db_cursor(MONETDB_LOCALNODETMP_PORT)
 
 
-
-
 def insert_data_to_localnode(
-    table_name: str, table_values: List[List[Union[str, int, float]]],monetdb_localnode_port
+    table_name: str,
+    table_values: List[List[Union[str, int, float]]],
+    monetdb_localnode_port,
 ):
     row_length = len(table_values[0])
     if all(len(row) != row_length for row in table_values):
         raise Exception("Not all rows have the same number of values")
 
     # rows= ["(" + ",".join(map(str, sublist)) + ")" for sublist in table_values]
-    table_values = [[item if item is not None else 'None' for item in sublist] for sublist in table_values]
-    rows= ["(" + ",".join(map(repr, sublist)) + ")" for sublist in table_values]
-    
+    table_values = [
+        [item if item is not None else "None" for item in sublist]
+        for sublist in table_values
+    ]
+    rows = ["(" + ",".join(map(repr, sublist)) + ")" for sublist in table_values]
+
     # rows = [str(tuple(sub)) for sub in table_values]
     # rows = [item.replace('None', "'None'") for item in rows]
 
-    
     # In order to achieve insertion with parameters we need to create query to the following format:
     # INSERT INTO <table_name> VALUES (%s, %s), (%s, %s);
     # The following variable 'values' create that specific str according to row_length and the amount of the rows.
@@ -590,6 +592,7 @@ def insert_data_to_localnode(
     # breakpoint()
     # with cursor(commit=True) as cur:
     #     cursor.execute(sql_clause,list(chain(*table_values)))
+
 
 def _clean_db(cursor):
     class TableType(enum.Enum):

--- a/tests/standalone_tests/conftest.py
+++ b/tests/standalone_tests/conftest.py
@@ -559,10 +559,10 @@ def localnodetmp_db_cursor():
     return _create_db_cursor(MONETDB_LOCALNODETMP_PORT)
 
 
-def insert_data_to_localnode(
+def insert_data_to_db(
     table_name: str,
     table_values: List[List[Union[str, int, float]]],
-    monetdb_localnode_port,
+    db_port,
 ):
     row_length = len(table_values[0])
     if all(len(row) != row_length for row in table_values):
@@ -576,7 +576,7 @@ def insert_data_to_localnode(
     )
     sql_clause = f"INSERT INTO {table_name} VALUES {values}"
 
-    cursor = _create_db_cursor(monetdb_localnode_port)
+    cursor = _create_db_cursor(db_port)
     cursor.execute(sql_clause, list(chain(*table_values)))
 
 

--- a/tests/standalone_tests/test_local_global_nodes_flow.py
+++ b/tests/standalone_tests/test_local_global_nodes_flow.py
@@ -42,8 +42,10 @@ def test_create_merge_table_with_remote_tables(
     context_id,
     localnode1_node_service,
     localnode1_celery_app,
+    localnode1_db_cursor,
     localnode2_node_service,
     localnode2_celery_app,
+    localnode2_db_cursor,
     globalnode_node_service,
     globalnode_celery_app,
 ):
@@ -92,8 +94,8 @@ def test_create_merge_table_with_remote_tables(
 
     # Insert data into local tables
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    insert_data_to_db(local_node_1_table_info.name, values, MONETDB_LOCALNODE1_PORT)
-    insert_data_to_db(local_node_2_table_info.name, values, MONETDB_LOCALNODE2_PORT)
+    insert_data_to_db(local_node_1_table_info.name, values, localnode1_db_cursor)
+    insert_data_to_db(local_node_2_table_info.name, values, localnode2_db_cursor)
 
     # Create remote tables
     local_node_1_monetdb_sock_address = f"{str(COMMON_IP)}:{MONETDB_LOCALNODE1_PORT}"

--- a/tests/standalone_tests/test_local_global_nodes_flow.py
+++ b/tests/standalone_tests/test_local_global_nodes_flow.py
@@ -13,9 +13,12 @@ from tests.standalone_tests.conftest import MONETDB_LOCALNODE2_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
+from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE2_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
-insert_task_signature = get_celery_task_signature("insert_data_to_table")
+# insert_task_signature = get_celery_task_signature("insert_data_to_table")
 create_remote_task_signature = get_celery_task_signature("create_remote_table")
 get_remote_tables_task_signature = get_celery_task_signature("get_remote_tables")
 create_merge_task_signature = get_celery_task_signature("create_merge_table")
@@ -92,32 +95,36 @@ def test_create_merge_table_with_remote_tables(
 
     # Insert data into local tables
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    async_result = localnode1_celery_app.queue_task(
-        task_signature=insert_task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=local_node_1_table_info.name,
-        values=values,
-    )
-    localnode1_celery_app.get_result(
-        async_result=async_result,
-        logger=StdOutputLogger(),
-        timeout=TASKS_TIMEOUT,
-    )
+    # async_result = localnode1_celery_app.queue_task(
+    #     task_signature=insert_task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=local_node_1_table_info.name,
+    #     values=values,
+    # )
+    # localnode1_celery_app.get_result(
+    #     async_result=async_result,
+    #     logger=StdOutputLogger(),
+    #     timeout=TASKS_TIMEOUT,
+    # )
+    insert_data_to_localnode(local_node_1_table_info.name,values,MONETDB_LOCALNODE1_PORT)
 
-    async_result = localnode2_celery_app.queue_task(
-        task_signature=insert_task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=local_node_2_table_info.name,
-        values=values,
-    )
 
-    localnode2_celery_app.get_result(
-        async_result=async_result,
-        logger=StdOutputLogger(),
-        timeout=TASKS_TIMEOUT,
-    )
+    # async_result = localnode2_celery_app.queue_task(
+    #     task_signature=insert_task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=local_node_2_table_info.name,
+    #     values=values,
+    # )
+
+    # localnode2_celery_app.get_result(
+    #     async_result=async_result,
+    #     logger=StdOutputLogger(),
+    #     timeout=TASKS_TIMEOUT,
+    # )
+    insert_data_to_localnode(local_node_2_table_info.name,values,MONETDB_LOCALNODE2_PORT)
+
 
     # Create remote tables
     local_node_1_monetdb_sock_address = f"{str(COMMON_IP)}:{MONETDB_LOCALNODE1_PORT}"

--- a/tests/standalone_tests/test_local_global_nodes_flow.py
+++ b/tests/standalone_tests/test_local_global_nodes_flow.py
@@ -11,12 +11,11 @@ from tests.standalone_tests.conftest import COMMON_IP
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE2_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 
 create_table_task_signature = get_celery_task_signature("create_table")
-# insert_task_signature = get_celery_task_signature("insert_data_to_table")
 create_remote_task_signature = get_celery_task_signature("create_remote_table")
 get_remote_tables_task_signature = get_celery_task_signature("get_remote_tables")
 create_merge_task_signature = get_celery_task_signature("create_merge_table")
@@ -93,38 +92,8 @@ def test_create_merge_table_with_remote_tables(
 
     # Insert data into local tables
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    # async_result = localnode1_celery_app.queue_task(
-    #     task_signature=insert_task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=local_node_1_table_info.name,
-    #     values=values,
-    # )
-    # localnode1_celery_app.get_result(
-    #     async_result=async_result,
-    #     logger=StdOutputLogger(),
-    #     timeout=TASKS_TIMEOUT,
-    # )
-    insert_data_to_localnode(
-        local_node_1_table_info.name, values, MONETDB_LOCALNODE1_PORT
-    )
-
-    # async_result = localnode2_celery_app.queue_task(
-    #     task_signature=insert_task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=local_node_2_table_info.name,
-    #     values=values,
-    # )
-
-    # localnode2_celery_app.get_result(
-    #     async_result=async_result,
-    #     logger=StdOutputLogger(),
-    #     timeout=TASKS_TIMEOUT,
-    # )
-    insert_data_to_localnode(
-        local_node_2_table_info.name, values, MONETDB_LOCALNODE2_PORT
-    )
+    insert_data_to_db(local_node_1_table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(local_node_2_table_info.name, values, MONETDB_LOCALNODE2_PORT)
 
     # Create remote tables
     local_node_1_monetdb_sock_address = f"{str(COMMON_IP)}:{MONETDB_LOCALNODE1_PORT}"

--- a/tests/standalone_tests/test_local_global_nodes_flow.py
+++ b/tests/standalone_tests/test_local_global_nodes_flow.py
@@ -11,11 +11,9 @@ from tests.standalone_tests.conftest import COMMON_IP
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE2_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
+from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
-from tests.standalone_tests.conftest import insert_data_to_localnode
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE2_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
 # insert_task_signature = get_celery_task_signature("insert_data_to_table")
@@ -107,8 +105,9 @@ def test_create_merge_table_with_remote_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(local_node_1_table_info.name,values,MONETDB_LOCALNODE1_PORT)
-
+    insert_data_to_localnode(
+        local_node_1_table_info.name, values, MONETDB_LOCALNODE1_PORT
+    )
 
     # async_result = localnode2_celery_app.queue_task(
     #     task_signature=insert_task_signature,
@@ -123,8 +122,9 @@ def test_create_merge_table_with_remote_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(local_node_2_table_info.name,values,MONETDB_LOCALNODE2_PORT)
-
+    insert_data_to_localnode(
+        local_node_2_table_info.name, values, MONETDB_LOCALNODE2_PORT
+    )
 
     # Create remote tables
     local_node_1_monetdb_sock_address = f"{str(COMMON_IP)}:{MONETDB_LOCALNODE1_PORT}"

--- a/tests/standalone_tests/test_merge_tables.py
+++ b/tests/standalone_tests/test_merge_tables.py
@@ -11,13 +11,12 @@ from exareme2.node_tasks_DTOs import TableSchema
 from exareme2.node_tasks_DTOs import TableType
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 
 create_table_task_signature = get_celery_task_signature("create_table")
 create_merge_table_task_signature = get_celery_task_signature("create_merge_table")
-# insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
 get_merge_tables_task_signature = get_celery_task_signature("get_merge_tables")
 
 
@@ -85,19 +84,7 @@ def create_three_column_table_with_data(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    # async_result = celery_app.queue_task(
-    #     task_signature=insert_data_to_table_task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # )
-    # celery_app.get_result(
-    #     async_result=async_result,
-    #     logger=StdOutputLogger(),
-    #     timeout=TASKS_TIMEOUT,
-    # )
-    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     return table_info
 

--- a/tests/standalone_tests/test_merge_tables.py
+++ b/tests/standalone_tests/test_merge_tables.py
@@ -58,7 +58,7 @@ def create_two_column_table(request_id, context_id, table_id: int, celery_app):
 
 
 def create_three_column_table_with_data(
-    request_id, context_id, table_id: int, celery_app
+    request_id, context_id, table_id: int, celery_app, db_cursor
 ):
     table_schema = TableSchema(
         columns=[
@@ -84,7 +84,7 @@ def create_three_column_table_with_data(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, db_cursor)
 
     return table_info
 
@@ -95,10 +95,11 @@ def test_create_and_get_merge_table(
     context_id,
     localnode1_node_service,
     localnode1_celery_app,
+    localnode1_db_cursor,
 ):
     tables_to_be_merged = [
         create_three_column_table_with_data(
-            request_id, context_id, count, localnode1_celery_app
+            request_id, context_id, count, localnode1_celery_app, localnode1_db_cursor
         )
         for count in range(0, 5)
     ]
@@ -138,15 +139,16 @@ def test_incompatible_schemas_merge(
     context_id,
     localnode1_node_service,
     localnode1_celery_app,
+    localnode1_db_cursor,
 ):
     incompatible_partition_tables = [
         create_three_column_table_with_data(
-            request_id, context_id, 1, localnode1_celery_app
+            request_id, context_id, 1, localnode1_celery_app, localnode1_db_cursor
         ),
         create_two_column_table(request_id, context_id, 2, localnode1_celery_app),
         create_two_column_table(request_id, context_id, 3, localnode1_celery_app),
         create_three_column_table_with_data(
-            request_id, context_id, 4, localnode1_celery_app
+            request_id, context_id, 4, localnode1_celery_app, localnode1_db_cursor
         ),
     ]
     async_result = localnode1_celery_app.queue_task(
@@ -174,13 +176,14 @@ def test_table_cannot_be_found(
     context_id,
     localnode1_node_service,
     localnode1_celery_app,
+    localnode1_db_cursor,
 ):
     not_found_tables = [
         create_three_column_table_with_data(
-            request_id, context_id, 1, localnode1_celery_app
+            request_id, context_id, 1, localnode1_celery_app, localnode1_db_cursor
         ),
         create_three_column_table_with_data(
-            request_id, context_id, 2, localnode1_celery_app
+            request_id, context_id, 2, localnode1_celery_app, localnode1_db_cursor
         ),
         TableInfo(
             name="non_existing_table",

--- a/tests/standalone_tests/test_merge_tables.py
+++ b/tests/standalone_tests/test_merge_tables.py
@@ -12,10 +12,12 @@ from exareme2.node_tasks_DTOs import TableType
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
+from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
 create_merge_table_task_signature = get_celery_task_signature("create_merge_table")
-insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
+# insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
 get_merge_tables_task_signature = get_celery_task_signature("get_merge_tables")
 
 
@@ -83,18 +85,19 @@ def create_three_column_table_with_data(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, "test2"], [3, 0.3, "test3"]]
-    async_result = celery_app.queue_task(
-        task_signature=insert_data_to_table_task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=table_info.name,
-        values=values,
-    )
-    celery_app.get_result(
-        async_result=async_result,
-        logger=StdOutputLogger(),
-        timeout=TASKS_TIMEOUT,
-    )
+    # async_result = celery_app.queue_task(
+    #     task_signature=insert_data_to_table_task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=table_info.name,
+    #     values=values,
+    # )
+    # celery_app.get_result(
+    #     async_result=async_result,
+    #     logger=StdOutputLogger(),
+    #     timeout=TASKS_TIMEOUT,
+    # )
+    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
 
     return table_info
 

--- a/tests/standalone_tests/test_merge_tables.py
+++ b/tests/standalone_tests/test_merge_tables.py
@@ -9,11 +9,11 @@ from exareme2.node_tasks_DTOs import ColumnInfo
 from exareme2.node_tasks_DTOs import TableInfo
 from exareme2.node_tasks_DTOs import TableSchema
 from exareme2.node_tasks_DTOs import TableType
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
+from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
-from tests.standalone_tests.conftest import insert_data_to_localnode
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
 create_merge_table_task_signature = get_celery_task_signature("create_merge_table")
@@ -97,7 +97,7 @@ def create_three_column_table_with_data(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
+    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     return table_info
 

--- a/tests/standalone_tests/test_node_info_tasks_priority.py
+++ b/tests/standalone_tests/test_node_info_tasks_priority.py
@@ -10,6 +10,7 @@ from exareme2.node_tasks_DTOs import NodeUDFKeyArguments
 from exareme2.node_tasks_DTOs import NodeUDFPosArguments
 from exareme2.udfgen import make_unique_func_name
 from tests.algorithms.orphan_udfs import one_second_udf
+from tests.standalone_tests.conftest import MONETDB_GLOBALNODE_PORT
 from tests.standalone_tests.conftest import RABBITMQ_GLOBALNODE_ADDR
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.test_udfs import create_table_with_one_column_and_ten_rows
@@ -53,7 +54,7 @@ def test_node_info_tasks_have_higher_priority_over_other_tasks(
     cel_app_wrapper = CeleryAppFactory().get_celery_app(RABBITMQ_GLOBALNODE_ADDR)
 
     input_table_name, _ = create_table_with_one_column_and_ten_rows(
-        cel_app_wrapper, request_id
+        cel_app_wrapper, MONETDB_GLOBALNODE_PORT, request_id
     )
 
     # Queue an X amount of udfs to fill the rabbitmq.

--- a/tests/standalone_tests/test_node_info_tasks_priority.py
+++ b/tests/standalone_tests/test_node_info_tasks_priority.py
@@ -10,7 +10,6 @@ from exareme2.node_tasks_DTOs import NodeUDFKeyArguments
 from exareme2.node_tasks_DTOs import NodeUDFPosArguments
 from exareme2.udfgen import make_unique_func_name
 from tests.algorithms.orphan_udfs import one_second_udf
-from tests.standalone_tests.conftest import MONETDB_GLOBALNODE_PORT
 from tests.standalone_tests.conftest import RABBITMQ_GLOBALNODE_ADDR
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.test_udfs import create_table_with_one_column_and_ten_rows
@@ -48,13 +47,14 @@ def queue_one_second_udf(
 @pytest.mark.very_slow
 def test_node_info_tasks_have_higher_priority_over_other_tasks(
     globalnode_node_service,
+    globalnode_db_cursor,
     reset_celery_app_factory,
     get_controller_testing_logger,
 ):
     cel_app_wrapper = CeleryAppFactory().get_celery_app(RABBITMQ_GLOBALNODE_ADDR)
 
     input_table_name, _ = create_table_with_one_column_and_ten_rows(
-        cel_app_wrapper, MONETDB_GLOBALNODE_PORT, request_id
+        cel_app_wrapper, globalnode_db_cursor, request_id
     )
 
     # Queue an X amount of udfs to fill the rabbitmq.

--- a/tests/standalone_tests/test_smpc_node_tasks.py
+++ b/tests/standalone_tests/test_smpc_node_tasks.py
@@ -37,7 +37,7 @@ from tests.standalone_tests.conftest import MONETDB_SMPC_LOCALNODE2_PORT
 from tests.standalone_tests.conftest import SMPC_COORDINATOR_ADDRESS
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
 from tests.standalone_tests.conftest import get_node_config_by_id
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 
 request_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10] + "request"
@@ -51,7 +51,6 @@ def create_table_with_one_column_and_ten_rows(
     celery_app: Celery, monetdb_localnode_port
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
-    # insert_data_to_table_task = get_celery_task_signature("insert_data_to_table")
 
     table_schema = TableSchema(
         columns=[
@@ -71,13 +70,7 @@ def create_table_with_one_column_and_ten_rows(
 
     values = [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
 
-    # celery_app.signature(insert_data_to_table_task).delay(
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # ).get(timeout=TASKS_TIMEOUT)
-
-    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
+    insert_data_to_db(table_info.name, values, monetdb_localnode_port)
 
     return table_info, 55
 
@@ -109,8 +102,6 @@ def create_secure_transfer_table(celery_app: Celery) -> TableInfo:
 def create_table_with_secure_transfer_results_with_smpc_off(
     celery_app: Celery, monetdb_localnode_port
 ) -> Tuple[TableInfo, int]:
-    # task_signature = get_celery_task_signature("insert_data_to_table")
-
     table_info = create_secure_transfer_table(celery_app)
 
     secure_transfer_1_value = 100
@@ -127,12 +118,7 @@ def create_table_with_secure_transfer_results_with_smpc_off(
         [json.dumps(secure_transfer_2)],
     ]
 
-    # celery_app.signature(task_signature).delay(
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
+    insert_data_to_db(table_info.name, values, monetdb_localnode_port)
 
     return table_info, secure_transfer_1_value + secure_transfer_2_value
 
@@ -140,8 +126,6 @@ def create_table_with_secure_transfer_results_with_smpc_off(
 def create_table_with_multiple_secure_transfer_templates(
     celery_app: Celery, monetdb_localnode_port: int, similar: bool
 ) -> TableInfo:
-    # task_signature = get_celery_task_signature("insert_data_to_table")
-
     table_info = create_secure_transfer_table(celery_app)
 
     secure_transfer_template = {
@@ -162,12 +146,7 @@ def create_table_with_multiple_secure_transfer_templates(
             [json.dumps(different_secure_transfer_template)],
         ]
 
-    # celery_app.signature(task_signature).delay(
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
+    insert_data_to_db(table_info.name, values, monetdb_localnode_port)
 
     return table_info
 
@@ -175,8 +154,6 @@ def create_table_with_multiple_secure_transfer_templates(
 def create_table_with_smpc_sum_op_values(
     celery_app: Celery, monetdb_localnode_port: int
 ) -> Tuple[TableInfo, str]:
-    # task_signature = get_celery_task_signature("insert_data_to_table")
-
     table_info = create_secure_transfer_table(celery_app)
 
     sum_op_values = [0, 1, 2, 3, 4, 5]
@@ -184,12 +161,7 @@ def create_table_with_smpc_sum_op_values(
         [json.dumps(sum_op_values)],
     ]
 
-    # celery_app.signature(task_signature).delay(
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
+    insert_data_to_db(table_info.name, values, monetdb_localnode_port)
 
     return table_info, json.dumps(sum_op_values)
 

--- a/tests/standalone_tests/test_smpc_node_tasks.py
+++ b/tests/standalone_tests/test_smpc_node_tasks.py
@@ -31,15 +31,14 @@ from tests.algorithms.orphan_udfs import smpc_global_step
 from tests.algorithms.orphan_udfs import smpc_local_step
 from tests.standalone_tests.conftest import LOCALNODE1_SMPC_CONFIG_FILE
 from tests.standalone_tests.conftest import LOCALNODE2_SMPC_CONFIG_FILE
-from tests.standalone_tests.conftest import SMPC_COORDINATOR_ADDRESS
-from tests.standalone_tests.conftest import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import get_node_config_by_id
-from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
-from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import MONETDB_SMPC_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import MONETDB_SMPC_LOCALNODE2_PORT
-
+from tests.standalone_tests.conftest import SMPC_COORDINATOR_ADDRESS
+from tests.standalone_tests.conftest import TASKS_TIMEOUT
+from tests.standalone_tests.conftest import get_node_config_by_id
+from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 
 request_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10] + "request"
 context_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10]
@@ -49,8 +48,7 @@ SMPC_GET_DATASET_ENDPOINT = "/api/update-dataset/"
 
 
 def create_table_with_one_column_and_ten_rows(
-    celery_app: Celery,
-    monetdb_localnode_port
+    celery_app: Celery, monetdb_localnode_port
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
     # insert_data_to_table_task = get_celery_task_signature("insert_data_to_table")
@@ -79,7 +77,7 @@ def create_table_with_one_column_and_ten_rows(
     #     values=values,
     # ).get(timeout=TASKS_TIMEOUT)
 
-    insert_data_to_localnode(table_info.name,values,monetdb_localnode_port)
+    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
 
     return table_info, 55
 
@@ -109,8 +107,7 @@ def create_secure_transfer_table(celery_app: Celery) -> TableInfo:
 
 # TODO More dynamic so it can receive any secure_transfer values
 def create_table_with_secure_transfer_results_with_smpc_off(
-    celery_app: Celery,
-    monetdb_localnode_port
+    celery_app: Celery, monetdb_localnode_port
 ) -> Tuple[TableInfo, int]:
     # task_signature = get_celery_task_signature("insert_data_to_table")
 
@@ -135,16 +132,13 @@ def create_table_with_secure_transfer_results_with_smpc_off(
     #     table_name=table_info.name,
     #     values=values,
     # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name,values,monetdb_localnode_port)
+    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
 
-    
     return table_info, secure_transfer_1_value + secure_transfer_2_value
 
 
 def create_table_with_multiple_secure_transfer_templates(
-    celery_app: Celery,
-    monetdb_localnode_port:int,
-    similar: bool
+    celery_app: Celery, monetdb_localnode_port: int, similar: bool
 ) -> TableInfo:
     # task_signature = get_celery_task_signature("insert_data_to_table")
 
@@ -173,14 +167,13 @@ def create_table_with_multiple_secure_transfer_templates(
     #     table_name=table_info.name,
     #     values=values,
     # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name,values,monetdb_localnode_port)
+    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
 
     return table_info
 
 
 def create_table_with_smpc_sum_op_values(
-        celery_app: Celery,
-        monetdb_localnode_port:int
+    celery_app: Celery, monetdb_localnode_port: int
 ) -> Tuple[TableInfo, str]:
     # task_signature = get_celery_task_signature("insert_data_to_table")
 
@@ -196,7 +189,7 @@ def create_table_with_smpc_sum_op_values(
     #     table_name=table_info.name,
     #     values=values,
     # ).get(timeout=TASKS_TIMEOUT)
-    insert_data_to_localnode(table_info.name,values,monetdb_localnode_port)
+    insert_data_to_localnode(table_info.name, values, monetdb_localnode_port)
 
     return table_info, json.dumps(sum_op_values)
 
@@ -229,8 +222,7 @@ def test_secure_transfer_output_with_smpc_off(
     get_table_data_task = get_celery_task_signature("get_table_data")
 
     input_table_info, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app,
-        MONETDB_LOCALNODE1_PORT
+        localnode1_celery_app, MONETDB_LOCALNODE1_PORT
     )
 
     pos_args_str = NodeUDFPosArguments(
@@ -277,7 +269,9 @@ def test_secure_transfer_input_with_smpc_off(
     (
         secure_transfer_results_tableinfo,
         secure_transfer_results_values_sum,
-    ) = create_table_with_secure_transfer_results_with_smpc_off(localnode1_celery_app,MONETDB_LOCALNODE1_PORT)
+    ) = create_table_with_secure_transfer_results_with_smpc_off(
+        localnode1_celery_app, MONETDB_LOCALNODE1_PORT
+    )
 
     pos_args_str = NodeUDFPosArguments(
         args=[NodeTableDTO(value=secure_transfer_results_tableinfo)]
@@ -325,7 +319,7 @@ def test_validate_smpc_templates_match(
     )
 
     table_info = create_table_with_multiple_secure_transfer_templates(
-        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT,True
+        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT, True
     )
 
     try:
@@ -351,7 +345,7 @@ def test_validate_smpc_templates_dont_match(
     )
 
     table_info = create_table_with_multiple_secure_transfer_templates(
-        smpc_localnode1_celery_app,MONETDB_SMPC_LOCALNODE1_PORT, False
+        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT, False
     )
 
     with pytest.raises(ValueError) as exc:
@@ -376,8 +370,7 @@ def test_secure_transfer_run_udf_flow_with_smpc_on(
 
     # ----------------------- SECURE TRANSFER OUTPUT ----------------------
     input_table_name, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        smpc_localnode1_celery_app,
-        MONETDB_SMPC_LOCALNODE1_PORT
+        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT
     )
 
     pos_args_str = NodeUDFPosArguments(
@@ -487,7 +480,7 @@ def test_load_data_to_smpc_client(
 ):
     smpc_localnode1_celery_app = smpc_localnode1_celery_app._celery_app
     table_info, sum_op_values_str = create_table_with_smpc_sum_op_values(
-        smpc_localnode1_celery_app,MONETDB_SMPC_LOCALNODE1_PORT
+        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT
     )
     load_data_to_smpc_client_task = get_celery_task_signature(
         "load_data_to_smpc_client"
@@ -674,15 +667,13 @@ def test_orchestrate_SMPC_between_two_localnodes_and_the_globalnode(
         input_table_1_name,
         input_table_1_name_sum,
     ) = create_table_with_one_column_and_ten_rows(
-        smpc_localnode1_celery_app,
-        MONETDB_SMPC_LOCALNODE1_PORT
+        smpc_localnode1_celery_app, MONETDB_SMPC_LOCALNODE1_PORT
     )
     (
         input_table_2_name,
         input_table_2_name_sum,
     ) = create_table_with_one_column_and_ten_rows(
-        smpc_localnode2_celery_app,
-        MONETDB_SMPC_LOCALNODE2_PORT
+        smpc_localnode2_celery_app, MONETDB_SMPC_LOCALNODE2_PORT
     )
 
     # ---------------- RUN LOCAL UDFS WITH SECURE TRANSFER OUTPUT ----------------------

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -13,10 +13,12 @@ from exareme2.table_data_DTOs import ColumnDataStr
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
+from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
 get_tables_task_signature = get_celery_task_signature("get_tables")
-insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
+# insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
 get_table_data_task_signature = get_celery_task_signature("get_table_data")
 
 
@@ -78,18 +80,19 @@ def test_create_and_find_tables(
     assert table_1_info.name in tables
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    async_result = localnode1_celery_app.queue_task(
-        task_signature=insert_data_to_table_task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=table_1_info.name,
-        values=values,
-    )
-    localnode1_celery_app.get_result(
-        async_result=async_result,
-        logger=StdOutputLogger(),
-        timeout=TASKS_TIMEOUT,
-    )
+    # async_result = localnode1_celery_app.queue_task(
+    #     task_signature=insert_data_to_table_task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=table_1_info.name,
+    #     values=values,
+    # )
+    # localnode1_celery_app.get_result(
+    #     async_result=async_result,
+    #     logger=StdOutputLogger(),
+    #     timeout=TASKS_TIMEOUT,
+    # )
+    insert_data_to_localnode(table_1_info.name,values,MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,
@@ -143,18 +146,20 @@ def test_create_and_find_tables(
 
     values = [[1, 0.1, "test1"], [2, None, "None"], [3, 0.3, None]]
 
-    async_result = localnode1_celery_app.queue_task(
-        task_signature=insert_data_to_table_task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=table_2_info.name,
-        values=values,
-    )
-    localnode1_celery_app.get_result(
-        async_result=async_result,
-        logger=StdOutputLogger(),
-        timeout=TASKS_TIMEOUT,
-    )
+    # async_result = localnode1_celery_app.queue_task(
+    #     task_signature=insert_data_to_table_task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=table_2_info.name,
+    #     values=values,
+    # )
+    # localnode1_celery_app.get_result(
+    #     async_result=async_result,
+    #     logger=StdOutputLogger(),
+    #     timeout=TASKS_TIMEOUT,
+    # )
+    insert_data_to_localnode(table_2_info.name,values,MONETDB_LOCALNODE1_PORT)
+
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -12,7 +12,7 @@ from exareme2.table_data_DTOs import ColumnDataInt
 from exareme2.table_data_DTOs import ColumnDataStr
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 
@@ -92,7 +92,7 @@ def test_create_and_find_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(table_1_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_1_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,
@@ -158,7 +158,7 @@ def test_create_and_find_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(table_2_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_2_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -10,11 +10,11 @@ from exareme2.node_tasks_DTOs import TableSchema
 from exareme2.table_data_DTOs import ColumnDataFloat
 from exareme2.table_data_DTOs import ColumnDataInt
 from exareme2.table_data_DTOs import ColumnDataStr
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
+from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
-from tests.standalone_tests.conftest import insert_data_to_localnode
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 
 create_table_task_signature = get_celery_task_signature("create_table")
 get_tables_task_signature = get_celery_task_signature("get_tables")
@@ -92,7 +92,7 @@ def test_create_and_find_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(table_1_info.name,values,MONETDB_LOCALNODE1_PORT)
+    insert_data_to_localnode(table_1_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,
@@ -158,8 +158,7 @@ def test_create_and_find_tables(
     #     logger=StdOutputLogger(),
     #     timeout=TASKS_TIMEOUT,
     # )
-    insert_data_to_localnode(table_2_info.name,values,MONETDB_LOCALNODE1_PORT)
-
+    insert_data_to_localnode(table_2_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -18,7 +18,6 @@ from tests.standalone_tests.std_output_logger import StdOutputLogger
 
 create_table_task_signature = get_celery_task_signature("create_table")
 get_tables_task_signature = get_celery_task_signature("get_tables")
-# insert_data_to_table_task_signature = get_celery_task_signature("insert_data_to_table")
 get_table_data_task_signature = get_celery_task_signature("get_table_data")
 
 
@@ -80,18 +79,6 @@ def test_create_and_find_tables(
     assert table_1_info.name in tables
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    # async_result = localnode1_celery_app.queue_task(
-    #     task_signature=insert_data_to_table_task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_1_info.name,
-    #     values=values,
-    # )
-    # localnode1_celery_app.get_result(
-    #     async_result=async_result,
-    #     logger=StdOutputLogger(),
-    #     timeout=TASKS_TIMEOUT,
-    # )
     insert_data_to_db(table_1_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(
@@ -145,19 +132,6 @@ def test_create_and_find_tables(
     assert table_2_info.name in tables
 
     values = [[1, 0.1, "test1"], [2, None, "None"], [3, 0.3, None]]
-
-    # async_result = localnode1_celery_app.queue_task(
-    #     task_signature=insert_data_to_table_task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_2_info.name,
-    #     values=values,
-    # )
-    # localnode1_celery_app.get_result(
-    #     async_result=async_result,
-    #     logger=StdOutputLogger(),
-    #     timeout=TASKS_TIMEOUT,
-    # )
     insert_data_to_db(table_2_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     async_result = localnode1_celery_app.queue_task(

--- a/tests/standalone_tests/test_tables.py
+++ b/tests/standalone_tests/test_tables.py
@@ -39,6 +39,7 @@ def test_create_and_find_tables(
     context_id,
     localnode1_node_service,
     localnode1_celery_app,
+    localnode1_db_cursor,
 ):
     table_schema = TableSchema(
         columns=[
@@ -79,7 +80,7 @@ def test_create_and_find_tables(
     assert table_1_info.name in tables
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    insert_data_to_db(table_1_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_1_info.name, values, localnode1_db_cursor)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,
@@ -132,7 +133,7 @@ def test_create_and_find_tables(
     assert table_2_info.name in tables
 
     values = [[1, 0.1, "test1"], [2, None, "None"], [3, 0.3, None]]
-    insert_data_to_db(table_2_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_2_info.name, values, localnode1_db_cursor)
 
     async_result = localnode1_celery_app.queue_task(
         task_signature=get_table_data_task_signature,

--- a/tests/standalone_tests/test_udfs.py
+++ b/tests/standalone_tests/test_udfs.py
@@ -25,17 +25,15 @@ from exareme2.udfgen.udfgen_DTOs import UDFGenTableResult
 from tests.algorithms.orphan_udfs import get_column_rows
 from tests.algorithms.orphan_udfs import local_step
 from tests.algorithms.orphan_udfs import one_hundred_seconds_udf
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
+from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
-from tests.standalone_tests.conftest import insert_data_to_localnode
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
-
 
 command_id = "command123"
 request_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10] + "request"
 context_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10]
-
 
 
 # Alias locslnode1_db_cursor to db
@@ -45,7 +43,7 @@ def db(localnode1_db_cursor):
 
 
 def create_table_with_one_column_and_ten_rows(
-        celery_app, request_id,db
+    celery_app, request_id, db
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
     # insert_data_to_table_task = get_celery_task_signature("insert_data_to_table")
@@ -79,7 +77,7 @@ def create_table_with_one_column_and_ten_rows(
     # celery_app.get_result(
     #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT)
 
-    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
+    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     # breakpoint()
     # sql = f"""
@@ -132,14 +130,14 @@ def test_run_udf_state_and_transfer_output(
     use_localnode1_database,
     localnode1_db_cursor,
     localnode1_celery_app,
-    db
+    db,
 ):
     run_udf_task = get_celery_task_signature("run_udf")
 
     local_node_get_table_data = get_celery_task_signature("get_table_data")
 
     input_table_info, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app, request_id,db
+        localnode1_celery_app, request_id, db
     )
 
     kw_args_str = NodeUDFKeyArguments(
@@ -245,12 +243,12 @@ def test_run_udf_with_remote_state_table_passed_as_normal_table(
 @pytest.mark.skip(reason="https://team-1617704806227.atlassian.net/browse/MIP-473")
 @pytest.mark.slow
 def test_slow_udf_exception(
-        localnode1_node_service, use_localnode1_database, localnode1_celery_app,db
+    localnode1_node_service, use_localnode1_database, localnode1_celery_app, db
 ):
     run_udf_task = get_celery_task_signature("run_udf")
 
     input_table_name, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app, request_id,db
+        localnode1_celery_app, request_id, db
     )
 
     kw_args_str = NodeUDFKeyArguments(

--- a/tests/standalone_tests/test_udfs.py
+++ b/tests/standalone_tests/test_udfs.py
@@ -27,7 +27,7 @@ from tests.algorithms.orphan_udfs import local_step
 from tests.algorithms.orphan_udfs import one_hundred_seconds_udf
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 from tests.standalone_tests.conftest import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 
@@ -36,17 +36,10 @@ request_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10] + "request"
 context_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10]
 
 
-# Alias locslnode1_db_cursor to db
-@pytest.fixture(scope="module")
-def db(localnode1_db_cursor):
-    return localnode1_db_cursor
-
-
 def create_table_with_one_column_and_ten_rows(
-    celery_app, request_id, db
+    celery_app, monetdb_port, request_id
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
-    # insert_data_to_table_task = get_celery_task_signature("insert_data_to_table")
 
     table_schema = TableSchema(
         columns=[
@@ -67,38 +60,9 @@ def create_table_with_one_column_and_ten_rows(
         )
     )
     values = [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
-    # async_result = celery_app.queue_task(
-    #     task_signature=insert_data_to_table_task,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # )
-    # celery_app.get_result(
-    #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT)
 
-    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, monetdb_port)
 
-    # breakpoint()
-    # sql = f"""
-    # INSERT INTO {table_info.name} VALUES
-    # (0),
-    # (1),
-    # (2),
-    # (3),
-    # (4);
-    # """
-    # db.execute(sql)
-
-    # sql = f"""
-    # INSERT INTO {table_info.name} VALUES
-    # (0 , 1 , 'BL'  , 1 , 'a'),
-    # (1 , 1 , 'FL1' , 2 , 'b'),
-    # (2 , 1 , 'FL2' , 3 , 'b'),
-    # (3 , 2 , 'BL'  , 2 , 'a'),
-    # (4 , 2 , 'FL1' , 4 , 'b');
-    # """
-    # breakpoint()
     return table_info, 55
 
 
@@ -130,14 +94,13 @@ def test_run_udf_state_and_transfer_output(
     use_localnode1_database,
     localnode1_db_cursor,
     localnode1_celery_app,
-    db,
 ):
     run_udf_task = get_celery_task_signature("run_udf")
 
     local_node_get_table_data = get_celery_task_signature("get_table_data")
 
     input_table_info, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app, request_id, db
+        localnode1_celery_app, MONETDB_LOCALNODE1_PORT, request_id
     )
 
     kw_args_str = NodeUDFKeyArguments(
@@ -243,12 +206,12 @@ def test_run_udf_with_remote_state_table_passed_as_normal_table(
 @pytest.mark.skip(reason="https://team-1617704806227.atlassian.net/browse/MIP-473")
 @pytest.mark.slow
 def test_slow_udf_exception(
-    localnode1_node_service, use_localnode1_database, localnode1_celery_app, db
+    localnode1_node_service, use_localnode1_database, localnode1_celery_app
 ):
     run_udf_task = get_celery_task_signature("run_udf")
 
     input_table_name, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app, request_id, db
+        localnode1_celery_app, request_id
     )
 
     kw_args_str = NodeUDFKeyArguments(

--- a/tests/standalone_tests/test_udfs.py
+++ b/tests/standalone_tests/test_udfs.py
@@ -37,7 +37,7 @@ context_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10]
 
 
 def create_table_with_one_column_and_ten_rows(
-    celery_app, db_port, request_id
+    celery_app, db_cursor, request_id
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
 
@@ -60,8 +60,7 @@ def create_table_with_one_column_and_ten_rows(
         )
     )
     values = [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
-
-    insert_data_to_db(table_info.name, values, db_port)
+    insert_data_to_db(table_info.name, values, db_cursor)
 
     return table_info, 55
 
@@ -100,7 +99,7 @@ def test_run_udf_state_and_transfer_output(
     local_node_get_table_data = get_celery_task_signature("get_table_data")
 
     input_table_info, input_table_name_sum = create_table_with_one_column_and_ten_rows(
-        localnode1_celery_app, MONETDB_LOCALNODE1_PORT, request_id
+        localnode1_celery_app, localnode1_db_cursor, request_id
     )
 
     kw_args_str = NodeUDFKeyArguments(

--- a/tests/standalone_tests/test_udfs.py
+++ b/tests/standalone_tests/test_udfs.py
@@ -37,7 +37,7 @@ context_id = "testsmpcudfs" + str(uuid.uuid4().hex)[:10]
 
 
 def create_table_with_one_column_and_ten_rows(
-    celery_app, monetdb_port, request_id
+    celery_app, db_port, request_id
 ) -> Tuple[TableInfo, int]:
     create_table_task = get_celery_task_signature("create_table")
 
@@ -61,7 +61,7 @@ def create_table_with_one_column_and_ten_rows(
     )
     values = [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
 
-    insert_data_to_db(table_info.name, values, monetdb_port)
+    insert_data_to_db(table_info.name, values, db_port)
 
     return table_info, 55
 

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -14,7 +14,7 @@ from exareme2.node_tasks_DTOs import TableInfo
 from exareme2.node_tasks_DTOs import TableSchema
 from tests.standalone_tests.conftest import ALGORITHMS_URL
 from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
-from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import insert_data_to_db
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 from tests.standalone_tests.test_smpc_node_tasks import TASKS_TIMEOUT
@@ -128,7 +128,7 @@ def test_view_without_filters(
     # localnode1_celery_app.get_result(
     #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
     # )
-    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
     task_signature = get_celery_task_signature("create_view")
@@ -231,7 +231,7 @@ def test_view_with_filters(
     # localnode1_celery_app.get_result(
     #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
     # )
-    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
     filters = {

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -117,17 +117,6 @@ def test_view_without_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    # task_signature = get_celery_task_signature("insert_data_to_table")
-    # async_result = localnode1_celery_app.queue_task(
-    #     task_signature=task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # )
-    # localnode1_celery_app.get_result(
-    #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
-    # )
     insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
@@ -220,17 +209,6 @@ def test_view_with_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    # task_signature = get_celery_task_signature("insert_data_to_table")
-    # async_result = localnode1_celery_app.queue_task(
-    #     task_signature=task_signature,
-    #     logger=StdOutputLogger(),
-    #     request_id=request_id,
-    #     table_name=table_info.name,
-    #     values=values,
-    # )
-    # localnode1_celery_app.get_result(
-    #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
-    # )
     insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -117,7 +117,7 @@ def test_view_without_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, localnode1_db_cursor)
 
     columns = ["col1", "col3"]
     task_signature = get_celery_task_signature("create_view")
@@ -182,8 +182,8 @@ def test_view_with_filters(
     context_id,
     load_data_localnode1,
     localnode1_node_service,
-    localnode1_celery_app,
     use_localnode1_database,
+    localnode1_db_cursor,
 ):
     table_schema = TableSchema(
         columns=[
@@ -209,7 +209,7 @@ def test_view_with_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    insert_data_to_db(table_info.name, values, MONETDB_LOCALNODE1_PORT)
+    insert_data_to_db(table_info.name, values, localnode1_db_cursor)
 
     columns = ["col1", "col3"]
     filters = {

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -13,11 +13,12 @@ from exareme2.node_tasks_DTOs import TableData
 from exareme2.node_tasks_DTOs import TableInfo
 from exareme2.node_tasks_DTOs import TableSchema
 from tests.standalone_tests.conftest import ALGORITHMS_URL
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
+from tests.standalone_tests.conftest import insert_data_to_localnode
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 from tests.standalone_tests.test_smpc_node_tasks import TASKS_TIMEOUT
-from tests.standalone_tests.conftest import insert_data_to_localnode
-from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
+
 
 @pytest.fixture
 def request_id():
@@ -127,8 +128,7 @@ def test_view_without_filters(
     # localnode1_celery_app.get_result(
     #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
     # )
-    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
-
+    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
     task_signature = get_celery_task_signature("create_view")
@@ -231,7 +231,7 @@ def test_view_with_filters(
     # localnode1_celery_app.get_result(
     #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
     # )
-    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
+    insert_data_to_localnode(table_info.name, values, MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
     filters = {

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -16,7 +16,8 @@ from tests.standalone_tests.conftest import ALGORITHMS_URL
 from tests.standalone_tests.nodes_communication_helper import get_celery_task_signature
 from tests.standalone_tests.std_output_logger import StdOutputLogger
 from tests.standalone_tests.test_smpc_node_tasks import TASKS_TIMEOUT
-
+from tests.standalone_tests.conftest import insert_data_to_localnode
+from tests.standalone_tests.conftest import MONETDB_LOCALNODE1_PORT
 
 @pytest.fixture
 def request_id():
@@ -115,17 +116,19 @@ def test_view_without_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    task_signature = get_celery_task_signature("insert_data_to_table")
-    async_result = localnode1_celery_app.queue_task(
-        task_signature=task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=table_info.name,
-        values=values,
-    )
-    localnode1_celery_app.get_result(
-        async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
-    )
+    # task_signature = get_celery_task_signature("insert_data_to_table")
+    # async_result = localnode1_celery_app.queue_task(
+    #     task_signature=task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=table_info.name,
+    #     values=values,
+    # )
+    # localnode1_celery_app.get_result(
+    #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
+    # )
+    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
+
 
     columns = ["col1", "col3"]
     task_signature = get_celery_task_signature("create_view")
@@ -217,17 +220,18 @@ def test_view_with_filters(
     )
 
     values = [[1, 0.1, "test1"], [2, 0.2, None], [3, 0.3, "test3"]]
-    task_signature = get_celery_task_signature("insert_data_to_table")
-    async_result = localnode1_celery_app.queue_task(
-        task_signature=task_signature,
-        logger=StdOutputLogger(),
-        request_id=request_id,
-        table_name=table_info.name,
-        values=values,
-    )
-    localnode1_celery_app.get_result(
-        async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
-    )
+    # task_signature = get_celery_task_signature("insert_data_to_table")
+    # async_result = localnode1_celery_app.queue_task(
+    #     task_signature=task_signature,
+    #     logger=StdOutputLogger(),
+    #     request_id=request_id,
+    #     table_name=table_info.name,
+    #     values=values,
+    # )
+    # localnode1_celery_app.get_result(
+    #     async_result=async_result, logger=StdOutputLogger(), timeout=TASKS_TIMEOUT
+    # )
+    insert_data_to_localnode(table_info.name,values,MONETDB_LOCALNODE1_PORT)
 
     columns = ["col1", "col3"]
     filters = {

--- a/tests/standalone_tests/test_views_and_filters.py
+++ b/tests/standalone_tests/test_views_and_filters.py
@@ -89,7 +89,7 @@ def test_view_without_filters(
     load_data_localnode1,
     localnode1_node_service,
     localnode1_celery_app,
-    use_localnode1_database,
+    localnode1_db_cursor,
 ):
     table_schema = TableSchema(
         columns=[
@@ -182,6 +182,7 @@ def test_view_with_filters(
     context_id,
     load_data_localnode1,
     localnode1_node_service,
+    localnode1_celery_app,
     use_localnode1_database,
     localnode1_db_cursor,
 ):


### PR DESCRIPTION
https://team-1617704806227.atlassian.net/browse/MIP-762

Celery task `insert_data_to_table` is removed. The way to add data to a node's db is through 
`tests/standalone_tests/conftest.py` `insert_data_to_db` function.  