### PR TITLE
core: Update Dockerfile Rabbitmq to 3.9.29

### DIFF
--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.9.14-management
+FROM rabbitmq:3.9.29-management
 
 ENV RABBITMQ_ADMIN_USER user
 ENV RABBITMQ_ADMIN_PASSWORD password


### PR DESCRIPTION
To be tested

However, this version is deprecated so after this upgrade, there should be upgrades to newer versions by doing so one by one.

Currently only 3.13 is supported: https://endoflife.date/rabbitmq
