### PR TITLE
 core: Update Dockerfile python to 3.8.19-slim-bullseye

### DIFF
--- a/exareme2/worker/Dockerfile
+++ b/exareme2/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.11-slim-buster
+FROM python:3.8.19-slim-bullseye
 MAINTAINER Thanasis Karampatsis <tkarabatsis@athenarc.gr>
 
 #######################################################


### PR DESCRIPTION


Latest from https://hub.docker.com/_/python, to be tested
