### PR TITLE
Added validations for variable group selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ pyrightconfig.json
 /configs
 /smpc_configs
 .stored_data/
+*.db

--- a/exareme2/controller/services/exareme2/controller.py
+++ b/exareme2/controller/services/exareme2/controller.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import itertools
 import traceback
 from abc import ABC
 from abc import abstractmethod
@@ -194,7 +195,7 @@ class DataModelViewsCreator:
             A boolean flag denoting if the 'Not Available' values will be kept in the
             "data model views" or not
         check_min_rows: bool
-            A boolean flag denoting if a "minimum row count threshol" will be in palce
+            A boolean flag denoting if a "minimum row count threshold" will be in place
             or not
         command_id: int
             A unique id
@@ -227,6 +228,12 @@ class DataModelViewsCreator:
 
         if self._data_model_views:
             return
+
+        if not list(itertools.chain(*self._variable_groups)):
+            raise ValueError(
+                "There are not variables in the 'variable_groups' of the algorithm. "
+                "Please check that the 'variable_groups' in the data loader are pointing to the proper variables."
+            )
 
         views_per_localworker = {}
         for worker in self._local_workers:

--- a/exareme2/controller/services/exareme2/tasks_handler.py
+++ b/exareme2/controller/services/exareme2/tasks_handler.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List
 from typing import Optional
 
@@ -87,6 +88,9 @@ class Exareme2TasksHandler:
         dropna: bool = True,
         check_min_rows: bool = True,
     ) -> List[TableInfo]:
+        if not list(itertools.chain(*columns_per_view)):
+            raise ValueError("'columns_per_view' are completely empty.")
+
         result_str = self._worker_tasks_handler.create_data_model_views(
             request_id=self._request_id,
             context_id=context_id,


### PR DESCRIPTION
In the case where the algorithm developer didn't select the proper variable in the 'get_group_variables' in the data loader, the error was being thrown much later and was very hard to trace.