### PR TITLE
feat: remove worker_id alphanumeric limitation by sanitizing non-alphanumerics

### DIFF
--- a/tests/standalone_tests/worker/exareme2/test_create_table_name.py
+++ b/tests/standalone_tests/worker/exareme2/test_create_table_name.py
@@ -43,13 +43,6 @@ def get_test_create_table_name_with_bad_parameters_cases():
     test_create_table_name_with_bad_parameters_cases = [
         (
             TableType.NORMAL,
-            "workerid_1",
-            "contextid2",
-            "commandid3",
-            "commandsubid4",
-        ),
-        (
-            TableType.NORMAL,
             "workerid1",
             "contextid_2",
             "commandid3",


### PR DESCRIPTION
- Drop strict isalnum() check for worker_id.
- Introduce `_to_alnum()` helper that strips any non [0-9A-Za-z] chars and raises if result is empty.
- Use `alphanumeric_worker_id` in the final table name.