### PR TITLE
Managed cluster configuration updates (Integration of Submariner)

### DIFF
--- a/kubernetes/templates/exareme2-controller.yaml
+++ b/kubernetes/templates/exareme2-controller.yaml
@@ -1,11 +1,14 @@
 # PVC for cleanup-file (only if using CephFS PVC)
-{{ if .Values.managed_cluster }}
+{{- if .Values.managed_cluster }}
 {{- if .Values.monetdb.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: cleanup-file-pvc
   namespace: {{ .Values.namespace }}
+  annotations:
+    # tells Argo CD: do not prune (delete) this resource
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
 spec:
   accessModes:
     - ReadWriteOnce
@@ -14,7 +17,7 @@ spec:
       storage: {{ .Values.storage.cephfs.controller.size }}
   storageClassName: {{ .Values.storage.cephfs.storageClassName }}
 {{- end }}
-{{ end }}
+{{- end }}
 
 ---
 
@@ -35,21 +38,21 @@ spec:
       labels:
         app: exareme2-controller
     spec:
-      {{ if not .Values.managed_cluster }}
+      {{- if not .Values.managed_cluster }}
       nodeSelector:
         master: "true"
-      {{ end }}
+      {{- end }}
 
       {{- if .Values.monetdb.enabled }}
       volumes:
         - name: cleanup-file
-        {{ if .Values.managed_cluster }}
+        {{- if .Values.managed_cluster }}
           persistentVolumeClaim:
             claimName: cleanup-file-pvc
-        {{ else }}
+        {{- else }}
           hostPath:
             path: {{ .Values.storage.hostPath.controller_cleanup }}
-        {{ end }}
+        {{- end }}
       {{- end }}
 
 
@@ -93,14 +96,14 @@ spec:
         - name: CELERY_TASKS_TIMEOUT
           value: {{ quote .Values.controller.celery_tasks_timeout }}
         - name: LOCALWORKERS_DNS
-          value: "exareme2-workers-service"
+          value: {{ quote .Values.controller.workers_dns }}
         - name: LOCALWORKERS_PORT
           value: "5672"
         - name: MONETDB_ENABLED
           value: {{ quote .Values.monetdb.enabled }}
         - name: SMPC_ENABLED
           value: {{ quote .Values.smpc.enabled }}
-        {{ if .Values.smpc.enabled }}
+        {{- if .Values.smpc.enabled }}
         - name: SMPC_OPTIONAL
           value: {{ quote .Values.smpc.optional }}
         - name: SMPC_COORDINATOR_IP
@@ -113,7 +116,7 @@ spec:
           value: {{ quote .Values.smpc.get_result_interval }}
         - name: SMPC_GET_RESULT_MAX_RETRIES
           value: {{ quote .Values.smpc.get_result_max_retries }}
-        {{ end }}
+        {{- end }}
         startupProbe:
           httpGet:
             path: /healthcheck
@@ -141,7 +144,7 @@ spec:
           value: "123qwe"
 
       - name: smpc-queue
-        image: {{ .Values.smpc.queue_image}}
+        image: {{ .Values.smpc.queue_image }}
         command: ["redis-server", "--requirepass", "agora"]
         ports:
           - containerPort: 6379
@@ -183,8 +186,7 @@ spec:
           value: exareme2-smpc-player2-service
         - name: PLAYER_REPO_2
           value: "http://$(PLAYER_IP_2):7002"
-      {{ end }}
-
+      {{- end }}
 ---
 
 apiVersion: v1
@@ -193,14 +195,18 @@ metadata:
   name: exareme2-controller-service
   namespace: {{ .Values.namespace }}
 spec:
+  {{- if not .Values.managed_cluster }}
   type: LoadBalancer
+  {{- end }}
   selector:
     app: exareme2-controller
   ports:
     - protocol: TCP
       port: 5000
       targetPort: 5000
+      {{- if not .Values.managed_cluster }}
       nodePort: 30000
+      {{- end }}
 
 ---
 
@@ -219,7 +225,7 @@ spec:
       targetPort: 5672
 
 
-{{ if .Values.smpc.enabled }}
+{{- if .Values.smpc.enabled }}
 ---
 
 ### --- SMPC Coordinator Service ---

--- a/kubernetes/templates/exareme2-globalnode.yaml
+++ b/kubernetes/templates/exareme2-globalnode.yaml
@@ -38,13 +38,10 @@ spec:
         app: exareme2-worker
         nodeType: globalworker
     spec:
-      {{ if not .Values.managed_cluster }}
+      {{- if not .Values.managed_cluster }}
       nodeSelector:
         master: "true"
-      {{ end }}
-
-        # Choose storage backend: hostPath or dynamically provisioned CephFS PVCs
-      {{ if not .Values.managed_cluster }}
+      # Use hostPath storage on unmanaged clusters
       volumes:
         {{- if .Values.monetdb.enabled }}
         - name: db-data
@@ -58,7 +55,7 @@ spec:
           hostPath:
             path: {{ printf "%s/csvs" .Values.storage.hostPath.db.globalworker }}
 
-      {{ end }}
+      {{- end }}
       containers:
       {{- if .Values.monetdb.enabled }}
       - name: monetdb
@@ -81,12 +78,14 @@ spec:
         ports:
         - containerPort: 50000
         volumeMounts:
-        - mountPath: /home/monetdb
-          name: db-data
-        - mountPath: /opt/data
-          name: csv-data
-        - mountPath: /opt/credentials
-          name: credentials
+        {{- if .Values.monetdb.enabled }}
+        - name: db-data
+          mountPath: /home/monetdb
+        - name: credentials
+          mountPath: /opt/credentials
+        {{- end }}
+        - name: csv-data
+          mountPath: /opt/data
         startupProbe:
           exec:
             command:
@@ -104,7 +103,7 @@ spec:
             - -s
             - "select 1;"
           periodSeconds: 30
-      {{ end }}
+      {{- end }}
 
       - name: db-importer
         image: {{ .Values.exareme2_images.repository }}/exareme2_mipdb:{{ .Values.exareme2_images.version }}
@@ -125,7 +124,7 @@ spec:
         {{- if .Values.monetdb.enabled }}
         - mountPath: /opt/credentials
           name: credentials
-        {{ end }}
+        {{- end }}
 
       - name: rabbitmq
         image: {{ .Values.exareme2_images.repository }}/exareme2_rabbitmq:{{ .Values.exareme2_images.version }}
@@ -164,7 +163,7 @@ spec:
         {{- if .Values.monetdb.enabled }}
         - mountPath: /opt/credentials
           name: credentials
-        {{ end }}
+        {{- end }}
         - mountPath: /opt/data
           name: csv-data
         env:
@@ -212,7 +211,7 @@ spec:
           value: {{ .Values.globalworker_identifier }}
         - name: SMPC_ENABLED
           value: {{ quote .Values.smpc.enabled }}
-        {{ if .Values.smpc.enabled }}
+        {{- if .Values.smpc.enabled }}
         - name: SMPC_OPTIONAL
           value: {{ quote .Values.smpc.optional }}
         - name: SMPC_CLIENT_ID
@@ -223,7 +222,7 @@ spec:
           value: exareme2-smpc-coordinator-service
         - name: SMPC_COORDINATOR_ADDRESS
           value: "http://$(SMPC_COORDINATOR_IP):12314"
-        {{ end }}
+        {{- end }}
         startupProbe:
           exec:
             command:
@@ -241,35 +240,41 @@ spec:
               - exareme2.worker.healthcheck
           periodSeconds: 30
           timeoutSeconds: 10
-      {{ if .Values.managed_cluster }}
-      volumeClaimTemplates:
-        - metadata:
-            name: csv-data
-          spec:
-            storageClassName: {{ .Values.storage.cephfs.storageClassName }}
-            accessModes: {{ toYaml .Values.storage.cephfs.globalworker.csvs.accessModes | nindent 6 }}
-            resources:
-              requests:
-                storage: {{ .Values.storage.cephfs.globalworker.csvs.size }}
-
-        {{- if .Values.monetdb.enabled }}
-        - metadata:
-            name: db-data
-          spec:
-            storageClassName: {{ .Values.storage.cephfs.storageClassName }}
-            accessModes: {{ toYaml .Values.storage.cephfs.globalworker.db.accessModes | nindent 6 }}
-            resources:
-              requests:
-                storage: {{ .Values.storage.cephfs.globalworker.db.size }}
-        - metadata:
-            name: credentials
-            spec:
-              storageClassName: {{ .Values.storage.cephfs.storageClassName }}
-              accessModes: {{ toYaml .Values.storage.cephfs.globalworker.creds.accessModes | nindent 6 }}
-              resources:
-                requests:
-                  storage: {{ .Values.storage.cephfs.globalworker.creds.size }}
-        {{ end }}
-
-
-      {{ end }}
+  {{- if .Values.managed_cluster }}
+  volumeClaimTemplates:
+  - metadata:
+      name: csv-data
+      annotations:
+        # tells Argo CD: do not prune (delete) this resource
+        argocd.argoproj.io/sync-options: Delete=false,Prune=false
+    spec:
+      storageClassName: {{ .Values.storage.cephfs.storageClassName }}
+      accessModes: {{ toYaml .Values.storage.cephfs.globalworker.csvs.accessModes | nindent 6 }}
+      resources:
+        requests:
+          storage: {{ .Values.storage.cephfs.globalworker.csvs.size }}
+  {{- if .Values.monetdb.enabled }}
+  - metadata:
+      name: db-data
+      annotations:
+        # tells Argo CD: do not prune (delete) this resource
+        argocd.argoproj.io/sync-options: Delete=false,Prune=false
+    spec:
+      storageClassName: {{ .Values.storage.cephfs.storageClassName }}
+      accessModes: {{ toYaml .Values.storage.cephfs.globalworker.db.accessModes | nindent 6 }}
+      resources:
+        requests:
+          storage: {{ .Values.storage.cephfs.globalworker.db.size }}
+  - metadata:
+      name: credentials
+      annotations:
+        # tells Argo CD: do not prune (delete) this resource
+        argocd.argoproj.io/sync-options: Delete=false,Prune=false
+    spec:
+      storageClassName: {{ .Values.storage.cephfs.storageClassName }}
+      accessModes: {{ toYaml .Values.storage.cephfs.globalworker.creds.accessModes | nindent 6 }}
+      resources:
+        requests:
+          storage: {{ .Values.storage.cephfs.globalworker.creds.size }}
+  {{- end }}
+  {{- end }}

--- a/kubernetes/templates/exareme2-localnode.yaml
+++ b/kubernetes/templates/exareme2-localnode.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.localnodes) 0 }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -108,9 +109,13 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: SQLITE_DB_NAME
+          {{- if .Values.managed_cluster }}
+          value: "data_models"
+          {{- else}}
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+          {{- end }}
         - name: DB_PORT
           value: "50000"
         volumeMounts:
@@ -153,7 +158,11 @@ spec:
           timeoutSeconds: 10
 
       - name: worker
-        image: {{ .Values.exareme2_images.repository }}/exareme2_worker:{{ .Values.exareme2_images.version }}
+        {{- if .Values.managed_cluster }}
+        image: {{ .Values.exareme2_images.repository }}/exareme2_worker:removed_worker_id_limitation
+        {{- else}}
+        image: {{ .Values.exareme2_images.repository }}/{{ .Values.exareme2_images.version }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.monetdb.enabled }}
         - mountPath: /opt/credentials
@@ -205,9 +214,13 @@ spec:
         - name: MONETDB_PUBLIC_PASSWORD
           value: "guest"
         - name: SQLITE_DB_NAME
+          {{- if .Values.managed_cluster }}
+          value: "data_models"
+          {{- else}}
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+          {{- end }}
         - name: SMPC_ENABLED
           value: {{ quote .Values.smpc.enabled }}
         {{ if .Values.smpc.enabled }}
@@ -273,11 +286,14 @@ spec:
           value: "http://$(PLAYER_IP_2):7002"
       {{ end }}
 
-  {{ if .Values.managed_cluster }}
+  {{- if .Values.managed_cluster }}
   volumeClaimTemplates:
     {{- if .Values.monetdb.enabled }}
     - metadata:
         name: db-data
+        annotations:
+          # tells Argo CD: do not prune (delete) this resource
+          argocd.argoproj.io/sync-options: Delete=false,Prune=false
       spec:
         storageClassName: {{ .Values.storage.cephfs.storageClassName }}
         accessModes:
@@ -287,6 +303,9 @@ spec:
             storage: {{ .Values.storage.cephfs.localworker.db.size }}
     - metadata:
         name: credentials
+        annotations:
+          # tells Argo CD: do not prune (delete) this resource
+          argocd.argoproj.io/sync-options: Delete=false,Prune=false
       spec:
         storageClassName: {{ .Values.storage.cephfs.storageClassName }}
         accessModes:
@@ -294,10 +313,13 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.cephfs.localworker.creds.size }}
-    {{ end }}
+    {{- end }}
 
     - metadata:
         name: csv-data
+        annotations:
+          # tells Argo CD: do not prune (delete) this resource
+          argocd.argoproj.io/sync-options: Delete=false,Prune=false
       spec:
         storageClassName: {{ .Values.storage.cephfs.storageClassName }}
         accessModes:
@@ -306,7 +328,7 @@ spec:
           requests:
             storage: {{ .Values.storage.cephfs.localworker.csvs.size }}
 
-  {{ end }}
+  {{- end }}
 #---  # Used for SMPC cluster debugging
 #
 #apiVersion: v1
@@ -323,3 +345,4 @@ spec:
 #      port: 9000
 #      targetPort: 9000
 #      nodePort: 32000
+{{- end }}

--- a/kubernetes/templates/exareme2-localnode.yaml
+++ b/kubernetes/templates/exareme2-localnode.yaml
@@ -161,7 +161,7 @@ spec:
         {{- if .Values.managed_cluster }}
         image: {{ .Values.exareme2_images.repository }}/exareme2_worker:removed_worker_id_limitation
         {{- else}}
-        image: {{ .Values.exareme2_images.repository }}/{{ .Values.exareme2_images.version }}
+        image: {{ .Values.exareme2_images.repository }}/exareme2_worker:{{ .Values.exareme2_images.version }}
         {{- end }}
         volumeMounts:
         {{- if .Values.monetdb.enabled }}

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -25,6 +25,7 @@ flower:
   server_port: 8080
 
 controller:
+  workers_dns: "exareme2-workers-service"
   worker_landscape_aggregator_update_interval: 30
   celery_tasks_timeout: 300
   workers_cleanup_interval: 60
@@ -54,7 +55,7 @@ storage:
       globalworker: "/opt/exareme2/globalworker"
 
   cephfs:
-    storageClassName: ceph-corbo-cephfs
+    storageClassName: ceph-corbo-cephfs-retain
 
     controller:
       size: 1Gi

--- a/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
+++ b/tests/prod_env_tests/deployment_configs/kubernetes_values.yaml
@@ -28,6 +28,7 @@ flower:
   server_port: 8080
 
 controller:
+  workers_dns: "exareme2-workers-service"
   worker_landscape_aggregator_update_interval: 20
   celery_tasks_timeout: 120
   workers_cleanup_interval: 60


### PR DESCRIPTION
- Updated StorageClass: `ceph-corbo-cephfs` → `ceph-corbo-cephfs-retain` to preserve data on restarts.
- Refactored Kubernetes templates: simplified `if` statements.
- Controller workers: DNS field now supports multiple entries.
- Aggregation Server: added flag to enable/disable.